### PR TITLE
feat: move api reference to /reference

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -29,7 +29,10 @@ app.doc("/openapi.json", {
     { name: "Other" },
   ],
 });
-app.get("/docs", apiReference({ spec: { url: "/openapi.json" } }));
+app.get("/docs", (c) => {
+  return c.redirect("/reference");
+});
+app.get("/reference", apiReference({ spec: { url: "/openapi.json" } }));
 app.onError((err, c) =>
   c.json<ErrorSchema>(
     { ok: false, message: err.message.replaceAll(/"/g, "'") },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Relocated the API reference page to /reference.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This should help prevent confusion between the docs hosted on docs.icssc.club and the reference hosted on anteaterapi.com