### PR TITLE
fix: resolve issues with deadlocking

### DIFF
--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -2,13 +2,8 @@ import "dotenv/config";
 
 import { defineConfig } from "drizzle-kit";
 
-const url = process.env.DB_URL;
-
-if (!url) throw new Error("Database URL not provided. Please check your .env file.");
-
 export default defineConfig({
   schema: "./src/schema.ts",
   out: "./migrations",
   dialect: "postgresql",
-  dbCredentials: { url },
 });

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "check:types": "tsc -p ./tsconfig.json -noEmit",
     "generate": "drizzle-kit generate",
-    "migrate": "drizzle-kit migrate",
+    "migrate": "tsx src/migrate.ts",
     "studio": "drizzle-kit studio"
   },
   "dependencies": {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,3 +1,7 @@
+import type { DrizzleConfig } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 
-export const database = (url: string) => drizzle(url);
+export const database = <TSchema extends Record<string, unknown>>(
+  url: string,
+  params?: DrizzleConfig<TSchema>,
+) => drizzle({ connection: { url, max: 1 }, ...params });

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,0 +1,17 @@
+import { dirname, join } from "node:path";
+import { exit } from "node:process";
+import { fileURLToPath } from "node:url";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import { database } from "./index.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function main() {
+  const url = process.env.DB_URL;
+  if (!url) throw new Error("Database URL not provided. Please check your .env file.");
+  const db = database(url);
+  await migrate(db, { migrationsFolder: join(__dirname, "../migrations") });
+  exit(0);
+}
+
+main().then();


### PR DESCRIPTION
## Description
While attempting to migrate the prod database to the latest version of the schema introduced in #12, I noticed that it failed due to a deadlock. Even after temporarily disabling the WebSoc scraper and killing all outstanding connections it would still resurface, and as it turns out limiting the connector to one connection resolved that issue.

Things are a bit murky because the old connections may not have been killed properly, but this should be a step in the right direction.

## Related Issue

Aims to address #5, but the jury is still out on whether this resolves the issue.

## How Has This Been Tested?

Tested locally, migration succeeded.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
