### PR TITLE
feat: scraper enhancements

### DIFF
--- a/apps/data-pipeline/course-scraper/src/index.ts
+++ b/apps/data-pipeline/course-scraper/src/index.ts
@@ -293,8 +293,9 @@ function parseRawCourse(meta: {
   department: string;
   departmentName: string;
   prereqs: Map<string, PrerequisiteTree> | undefined;
+  updatedAt: Date;
 }): typeof course.$inferInsert {
-  const { rawCourse, school, department, departmentName, prereqs } = meta;
+  const { rawCourse, school, department, departmentName, prereqs, updatedAt } = meta;
   const deptAndCourseNumber = rawCourse[0].trim().split(". ")[0].trim();
   const title = rawCourse[0].trim().split(". ").slice(1, -1).join(". ").trim();
   const units =
@@ -327,6 +328,7 @@ function parseRawCourse(meta: {
     overlap: courseMetaOrEmpty(rawCourse, "Overlaps with "),
     corequisites: courseMetaOrEmpty(rawCourse, "Corequisite: "),
     ...generateGEs(rawCourse),
+    updatedAt,
   };
 }
 
@@ -351,6 +353,7 @@ async function scrapeCoursesInDepartment(meta: {
   deptPath: string;
   prereqs: Map<string, PrerequisiteTree> | undefined;
 }) {
+  const updatedAt = new Date();
   const { db, deptCode, deptPath, prereqs } = meta;
   if (!prereqs) {
     logger.warn(`${deptCode} does not have a prerequisite mapping.`);
@@ -402,6 +405,7 @@ async function scrapeCoursesInDepartment(meta: {
         department: deptCode,
         departmentName,
         prereqs,
+        updatedAt,
       }),
     ),
   );

--- a/apps/data-pipeline/study-location-scraper/src/handler.ts
+++ b/apps/data-pipeline/study-location-scraper/src/handler.ts
@@ -5,5 +5,6 @@ export default {
   async scheduled(_, env) {
     const db = database(env.DB.connectionString);
     await doScrape(db);
+    await db.$client.end();
   },
 } satisfies ExportedHandler<Env>;

--- a/apps/data-pipeline/study-location-scraper/src/lib.ts
+++ b/apps/data-pipeline/study-location-scraper/src/lib.ts
@@ -263,7 +263,7 @@ export async function doScrape(db: ReturnType<typeof database>) {
       .insert(studyRoomSlot)
       .values(slotRows)
       .onConflictDoUpdate({
-        target: studyRoomSlot.id,
+        target: [studyRoomSlot.studyRoomId, studyRoomSlot.start, studyRoomSlot.end],
         set: conflictUpdateSetAllCols(studyRoomSlot),
       });
     await tx.delete(studyRoomSlot).where(lt(studyRoomSlot.end, new Date()));

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -652,7 +652,7 @@ const doDepartmentUpsert = async (
       lastScraped: updatedAt,
       lastDeptScraped: department,
     };
-    await db
+    await tx
       .insert(websocMeta)
       .values(websocMetaValues)
       .onConflictDoUpdate({ target: websocMeta.name, set: websocMetaValues });

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -84,10 +84,12 @@ const nameToTerm = (name: string): Term => ({
 const schoolMapper = (
   term: Term,
   { schoolName, schoolComment }: WebsocSchool,
+  updatedAt: Date,
 ): typeof websocSchool.$inferInsert => ({
   ...term,
   schoolName,
   schoolComment,
+  updatedAt,
 });
 
 const departmentMapper = (
@@ -100,6 +102,7 @@ const departmentMapper = (
     sectionCodeRangeComments,
     courseNumberRangeComments,
   }: WebsocDepartment,
+  updatedAt: Date,
 ): typeof websocDepartment.$inferInsert => ({
   ...term,
   schoolId,
@@ -108,6 +111,7 @@ const departmentMapper = (
   deptComment,
   sectionCodeRangeComments,
   courseNumberRangeComments,
+  updatedAt,
 });
 
 function courseMapper(
@@ -115,12 +119,14 @@ function courseMapper(
   departmentId: string,
   course: WebsocCourse,
   schoolName: string,
+  updatedAt: Date,
 ): typeof websocCourse.$inferInsert {
   return {
     ...term,
     departmentId,
     ...course,
     schoolName,
+    updatedAt,
   };
 }
 
@@ -306,6 +312,7 @@ function sectionMapper(
     numCurrentlyEnrolled,
     ...rest
   }: WebsocSection,
+  updatedAt: Date,
 ): typeof websocSection.$inferInsert {
   return {
     ...term,
@@ -325,6 +332,7 @@ function sectionMapper(
     numNewOnlyReserved: baseTenIntOrNull(numNewOnlyReserved),
     numCurrentlySectionEnrolled: baseTenIntOrNull(numCurrentlyEnrolled.sectionEnrolled),
     numCurrentlyTotalEnrolled: baseTenIntOrNull(numCurrentlyEnrolled.totalEnrolled),
+    updatedAt,
   };
 }
 
@@ -334,6 +342,7 @@ function meetingMapper(
   sectionCode: number,
   meeting: WebsocSectionMeeting,
   meetingIndex: number,
+  updatedAt: Date,
 ): typeof websocSectionMeeting.$inferInsert {
   const res: typeof websocSectionMeeting.$inferInsert = {
     ...term,
@@ -342,6 +351,7 @@ function meetingMapper(
     sectionId,
     sectionCode,
     meetingIndex,
+    updatedAt,
   };
   if (meeting.time.trim() === "TBA") return res;
   const { startTime, endTime } = parseStartAndEndTimes(meeting.time);
@@ -379,11 +389,13 @@ const doDepartmentUpsert = async (
   db: ReturnType<typeof database>,
   term: Term,
   resp: WebsocResponse,
+  department: string,
 ) =>
   await db.transaction(async (tx) => {
+    const updatedAt = new Date();
     const schools = await tx
       .insert(websocSchool)
-      .values(resp.schools.map((school) => schoolMapper(term, school)))
+      .values(resp.schools.map((school) => schoolMapper(term, school, updatedAt)))
       .onConflictDoUpdate({
         target: [websocSchool.year, websocSchool.quarter, websocSchool.schoolName],
         set: conflictUpdateSetAllCols(websocSchool),
@@ -397,7 +409,7 @@ const doDepartmentUpsert = async (
           .flatMap((school) =>
             school.departments.map((dept) => {
               const maybeSchool = schools.get(school.schoolName);
-              return maybeSchool ? departmentMapper(term, maybeSchool, dept) : undefined;
+              return maybeSchool ? departmentMapper(term, maybeSchool, dept, updatedAt) : undefined;
             }),
           )
           .filter(notNull),
@@ -422,7 +434,7 @@ const doDepartmentUpsert = async (
               dept.courses.map((course) => {
                 const maybeDept = departments.get(dept.deptCode);
                 return maybeDept
-                  ? courseMapper(term, maybeDept, course, school.schoolName)
+                  ? courseMapper(term, maybeDept, course, school.schoolName, updatedAt)
                   : undefined;
               }),
             ),
@@ -460,7 +472,7 @@ const doDepartmentUpsert = async (
               const maybeCourse = courses.get(
                 `${course.deptCode} ${course.courseNumber} (${course.courseTitle})`,
               );
-              return maybeCourse ? sectionMapper(term, maybeCourse, section) : undefined;
+              return maybeCourse ? sectionMapper(term, maybeCourse, section, updatedAt) : undefined;
             }),
           ),
         )
@@ -514,7 +526,7 @@ const doDepartmentUpsert = async (
       .insert(websocInstructor)
       .values(
         Array.from(new Set(sectionsToInstructors.values())).flatMap((names) =>
-          names.map((name) => ({ name })),
+          names.map((name) => ({ name, updatedAt })),
         ),
       )
       .onConflictDoNothing();
@@ -556,6 +568,7 @@ const doDepartmentUpsert = async (
                           Number.parseInt(section.sectionCode, 10),
                           meeting,
                           index,
+                          updatedAt,
                         )
                       : undefined;
                   }),
@@ -604,7 +617,7 @@ const doDepartmentUpsert = async (
           const firstSpace = location.indexOf(" ");
           const building = location.slice(0, firstSpace);
           const room = location.slice(firstSpace + 1);
-          return { building, room };
+          return { building, room, updatedAt };
         }),
       )
       .onConflictDoUpdate({
@@ -634,7 +647,15 @@ const doDepartmentUpsert = async (
         ],
         set: conflictUpdateSetAllCols(websocSectionMeetingToLocation),
       });
-    console.log();
+    const websocMetaValues = {
+      name: termToName(term),
+      lastScraped: updatedAt,
+      lastDeptScraped: department,
+    };
+    await db
+      .insert(websocMeta)
+      .values(websocMetaValues)
+      .onConflictDoUpdate({ target: websocMeta.name, set: websocMetaValues });
   });
 
 const getUniqueMeetings = (meetings: WebsocSectionMeeting[]) =>
@@ -760,23 +781,28 @@ async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
   console.log(`Updated GE data for ${updates.size} courses`);
 }
 
-export async function scrapeTerm(db: ReturnType<typeof database>, term: Term) {
+export async function scrapeTerm(
+  db: ReturnType<typeof database>,
+  term: Term,
+  departments: string[],
+) {
   const name = termToName(term);
   console.log(`Scraping term ${name}`);
-  for (const department of await getDepts(db)) {
+  for (const department of departments) {
     console.log(`Scraping department ${department}`);
     const resp = await request(term, { department, cancelledCourses: "Include" }).then(
       normalizeResponse,
     );
-    if (resp.schools.length) await doDepartmentUpsert(db, term, resp);
+    if (resp.schools.length) await doDepartmentUpsert(db, term, resp, department);
     await sleep(500);
   }
   await scrapeGEsForTerm(db, term);
   const lastScraped = new Date();
+  const values = { name, lastScraped, lastDeptScraped: null };
   await db
     .insert(websocMeta)
-    .values({ name, lastScraped })
-    .onConflictDoUpdate({ target: websocMeta.name, set: { lastScraped } });
+    .values(values)
+    .onConflictDoUpdate({ target: websocMeta.name, set: values });
 }
 
 export async function doScrape(db: ReturnType<typeof database>) {
@@ -791,15 +817,24 @@ export async function doScrape(db: ReturnType<typeof database>) {
         termsToScrape.map((term) => term.id),
       ),
     )
-    .orderBy(asc(websocMeta.lastScraped))
-    .then((rows) =>
-      rows.reduce((acc, row) => acc.set(row.name, row.lastScraped), new Map<string, Date>()),
-    );
-  const term = termsInDatabase.keys().next().value;
-  if (term) {
-    await scrapeTerm(db, nameToTerm(term));
+    .orderBy(asc(websocMeta.lastScraped));
+  const term = termsInDatabase.find((x) => x.lastDeptScraped !== null) ?? termsInDatabase[0];
+  if (term?.name) {
+    try {
+      const departments = await getDepts(db);
+      await scrapeTerm(
+        db,
+        nameToTerm(term.name),
+        term?.lastDeptScraped
+          ? departments.slice(departments.indexOf(term.lastDeptScraped))
+          : departments,
+      );
+    } catch (e) {
+      console.error(e);
+    }
   } else {
     console.log("Nothing to do.");
   }
+  await db.$client.end({ timeout: 5 });
   console.log("All done!");
 }

--- a/packages/db/migrations/0004_enhance_scraper.sql
+++ b/packages/db/migrations/0004_enhance_scraper.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "course" ALTER COLUMN "updated_at" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "websoc_course" ALTER COLUMN "updated_at" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "websoc_department" ALTER COLUMN "updated_at" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "websoc_instructor" ALTER COLUMN "updated_at" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "websoc_location" ALTER COLUMN "updated_at" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "websoc_school" ALTER COLUMN "updated_at" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "websoc_section" ALTER COLUMN "updated_at" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "websoc_section_meeting" ALTER COLUMN "updated_at" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "websoc_meta" ADD COLUMN "last_dept_scraped" varchar;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "study_room_slot_study_room_id_start_end_index" ON "study_room_slot" USING btree ("study_room_id","start","end");

--- a/packages/db/migrations/meta/0004_snapshot.json
+++ b/packages/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,2942 @@
+{
+  "id": "8fad7c87-2d45-40ec-b695-9b7b47a70656",
+  "prevId": "648b6269-d783-4155-98f9-0356fda37397",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.calendar_term": {
+      "name": "calendar_term",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "generated": {
+            "as": "\"calendar_term\".\"year\" || ' ' || CASE WHEN \"calendar_term\".\"quarter\" = 'Fall' THEN 'Fall' WHEN \"calendar_term\".\"quarter\" = 'Winter' THEN 'Winter' WHEN \"calendar_term\".\"quarter\" = 'Spring' THEN 'Spring' WHEN \"calendar_term\".\"quarter\" = 'Summer1' THEN 'Summer1' WHEN \"calendar_term\".\"quarter\" = 'Summer10wk' THEN 'Summer10wk' WHEN \"calendar_term\".\"quarter\" = 'Summer2' THEN 'Summer2' ELSE '' END",
+            "type": "stored"
+          }
+        },
+        "year": {
+          "name": "year",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "term",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction_start": {
+          "name": "instruction_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction_end": {
+          "name": "instruction_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finals_start": {
+          "name": "finals_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finals_end": {
+          "name": "finals_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soc_available": {
+          "name": "soc_available",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course": {
+      "name": "course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department_alias": {
+          "name": "department_alias",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_number": {
+          "name": "course_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_numeric": {
+          "name": "course_numeric",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "CASE REGEXP_REPLACE(\"course\".\"course_number\", '\\D', '', 'g') WHEN '' THEN 0 ELSE REGEXP_REPLACE(\"course\".\"course_number\", '\\D', '', 'g')::INTEGER END",
+            "type": "stored"
+          }
+        },
+        "school": {
+          "name": "school",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_level": {
+          "name": "course_level",
+          "type": "course_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_units": {
+          "name": "min_units",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_units": {
+          "name": "max_units",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department_name": {
+          "name": "department_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_tree": {
+          "name": "prerequisite_tree",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_text": {
+          "name": "prerequisite_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repeatability": {
+          "name": "repeatability",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grading_option": {
+          "name": "grading_option",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "concurrent": {
+          "name": "concurrent",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "same_as": {
+          "name": "same_as",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restriction": {
+          "name": "restriction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overlap": {
+          "name": "overlap",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corequisites": {
+          "name": "corequisites",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_1a": {
+          "name": "is_ge_1a",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_1b": {
+          "name": "is_ge_1b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_2": {
+          "name": "is_ge_2",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_3": {
+          "name": "is_ge_3",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_4": {
+          "name": "is_ge_4",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_5a": {
+          "name": "is_ge_5a",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_5b": {
+          "name": "is_ge_5b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_6": {
+          "name": "is_ge_6",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_7": {
+          "name": "is_ge_7",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_8": {
+          "name": "is_ge_8",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ge_text": {
+          "name": "ge_text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "course_search_index": {
+          "name": "course_search_index",
+          "columns": [
+            {
+              "expression": "(\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"id\", '')), 'A') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"department\", '')), 'B') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"department_alias\", '')), 'B') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"course_number\", '')), 'B') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"course_numeric\"::TEXT, '')), 'B') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"title\", '')), 'C') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"description\", '')), 'D')\n)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.degree": {
+      "name": "degree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "division",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instructor": {
+      "name": "instructor",
+      "schema": "",
+      "columns": {
+        "ucinetid": {
+          "name": "ucinetid",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "instructor_search_index": {
+          "name": "instructor_search_index",
+          "columns": [
+            {
+              "expression": "(\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"ucinetid\", '')), 'A') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"name\", '')), 'B') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"title\", '')), 'B')\n)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instructor_to_websoc_instructor": {
+      "name": "instructor_to_websoc_instructor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instructor_ucinetid": {
+          "name": "instructor_ucinetid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "websoc_instructor_name": {
+          "name": "websoc_instructor_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "instructor_to_websoc_instructor_instructor_ucinetid_index": {
+          "name": "instructor_to_websoc_instructor_instructor_ucinetid_index",
+          "columns": [
+            {
+              "expression": "instructor_ucinetid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instructor_to_websoc_instructor_websoc_instructor_name_index": {
+          "name": "instructor_to_websoc_instructor_websoc_instructor_name_index",
+          "columns": [
+            {
+              "expression": "websoc_instructor_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instructor_to_websoc_instructor_instructor_ucinetid_websoc_instructor_name_index": {
+          "name": "instructor_to_websoc_instructor_instructor_ucinetid_websoc_instructor_name_index",
+          "columns": [
+            {
+              "expression": "instructor_ucinetid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "websoc_instructor_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instructor_to_websoc_instructor_instructor_ucinetid_instructor_ucinetid_fk": {
+          "name": "instructor_to_websoc_instructor_instructor_ucinetid_instructor_ucinetid_fk",
+          "tableFrom": "instructor_to_websoc_instructor",
+          "tableTo": "instructor",
+          "columnsFrom": ["instructor_ucinetid"],
+          "columnsTo": ["ucinetid"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instructor_to_websoc_instructor_websoc_instructor_name_websoc_instructor_name_fk": {
+          "name": "instructor_to_websoc_instructor_websoc_instructor_name_websoc_instructor_name_fk",
+          "tableFrom": "instructor_to_websoc_instructor",
+          "tableTo": "websoc_instructor",
+          "columnsFrom": ["websoc_instructor_name"],
+          "columnsTo": ["name"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.larc_section": {
+      "name": "larc_section",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days": {
+          "name": "days",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructor": {
+          "name": "instructor",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bldg": {
+          "name": "bldg",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "larc_section_course_id_index": {
+          "name": "larc_section_course_id_index",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "larc_section_course_id_websoc_course_id_fk": {
+          "name": "larc_section_course_id_websoc_course_id_fk",
+          "tableFrom": "larc_section",
+          "tableTo": "websoc_course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major": {
+      "name": "major",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "degree_id": {
+          "name": "degree_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "major_degree_id_index": {
+          "name": "major_degree_id_index",
+          "columns": [
+            {
+              "expression": "degree_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_degree_id_degree_id_fk": {
+          "name": "major_degree_id_degree_id_fk",
+          "tableFrom": "major",
+          "tableTo": "degree",
+          "columnsFrom": ["degree_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.minor": {
+      "name": "minor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prerequisite": {
+      "name": "prerequisite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dep_dept": {
+          "name": "dep_dept",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_id": {
+          "name": "prerequisite_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dependency_id": {
+          "name": "dependency_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "prerequisite_dep_dept_index": {
+          "name": "prerequisite_dep_dept_index",
+          "columns": [
+            {
+              "expression": "dep_dept",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prerequisite_prerequisite_id_index": {
+          "name": "prerequisite_prerequisite_id_index",
+          "columns": [
+            {
+              "expression": "prerequisite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prerequisite_dependency_id_index": {
+          "name": "prerequisite_dependency_id_index",
+          "columns": [
+            {
+              "expression": "dependency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prerequisite_prerequisite_id_dependency_id_index": {
+          "name": "prerequisite_prerequisite_id_dependency_id_index",
+          "columns": [
+            {
+              "expression": "prerequisite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dependency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.specialization": {
+      "name": "specialization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "major_id": {
+          "name": "major_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "specialization_major_id_index": {
+          "name": "specialization_major_id_index",
+          "columns": [
+            {
+              "expression": "major_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "specialization_major_id_major_id_fk": {
+          "name": "specialization_major_id_major_id_fk",
+          "tableFrom": "specialization",
+          "tableTo": "major",
+          "columnsFrom": ["major_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.study_location": {
+      "name": "study_location",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.study_room": {
+      "name": "study_room",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "directions": {
+          "name": "directions",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tech_enhanced": {
+          "name": "tech_enhanced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_location_id": {
+          "name": "study_location_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "study_room_study_location_id_index": {
+          "name": "study_room_study_location_id_index",
+          "columns": [
+            {
+              "expression": "study_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "study_room_study_location_id_study_location_id_fk": {
+          "name": "study_room_study_location_id_study_location_id_fk",
+          "tableFrom": "study_room",
+          "tableTo": "study_location",
+          "columnsFrom": ["study_location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.study_room_slot": {
+      "name": "study_room_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "study_room_id": {
+          "name": "study_room_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start": {
+          "name": "start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end": {
+          "name": "end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_available": {
+          "name": "is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "study_room_slot_study_room_id_index": {
+          "name": "study_room_slot_study_room_id_index",
+          "columns": [
+            {
+              "expression": "study_room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "study_room_slot_study_room_id_start_end_index": {
+          "name": "study_room_slot_study_room_id_start_end_index",
+          "columns": [
+            {
+              "expression": "study_room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "study_room_slot_study_room_id_study_room_id_fk": {
+          "name": "study_room_slot_study_room_id_study_room_id_fk",
+          "tableFrom": "study_room_slot",
+          "tableTo": "study_room",
+          "columnsFrom": ["study_room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_course": {
+      "name": "websoc_course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "department_id": {
+          "name": "department_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "REPLACE(\"websoc_course\".\"dept_code\", ' ', '') || \"websoc_course\".\"course_number\"",
+            "type": "stored"
+          }
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "term",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_name": {
+          "name": "school_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dept_code": {
+          "name": "dept_code",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_title": {
+          "name": "course_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_number": {
+          "name": "course_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_numeric": {
+          "name": "course_numeric",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "CASE REGEXP_REPLACE(\"websoc_course\".\"course_number\", '\\D', '', 'g') WHEN '' THEN 0 ELSE REGEXP_REPLACE(\"websoc_course\".\"course_number\", '\\D', '', 'g')::INTEGER END",
+            "type": "stored"
+          }
+        },
+        "course_comment": {
+          "name": "course_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_link": {
+          "name": "prerequisite_link",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_1a": {
+          "name": "is_ge_1a",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_1b": {
+          "name": "is_ge_1b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_2": {
+          "name": "is_ge_2",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_3": {
+          "name": "is_ge_3",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_4": {
+          "name": "is_ge_4",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_5a": {
+          "name": "is_ge_5a",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_5b": {
+          "name": "is_ge_5b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_6": {
+          "name": "is_ge_6",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_7": {
+          "name": "is_ge_7",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_8": {
+          "name": "is_ge_8",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "websoc_course_department_id_index": {
+          "name": "websoc_course_department_id_index",
+          "columns": [
+            {
+              "expression": "department_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_course_id_index": {
+          "name": "websoc_course_course_id_index",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_school_name_dept_code_course_number_course_title_index": {
+          "name": "websoc_course_year_quarter_school_name_dept_code_course_number_course_title_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dept_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_1a_index": {
+          "name": "websoc_course_year_quarter_is_ge_1a_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_1a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_1b_index": {
+          "name": "websoc_course_year_quarter_is_ge_1b_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_1b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_2_index": {
+          "name": "websoc_course_year_quarter_is_ge_2_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_2",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_3_index": {
+          "name": "websoc_course_year_quarter_is_ge_3_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_3",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_4_index": {
+          "name": "websoc_course_year_quarter_is_ge_4_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_4",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_5a_index": {
+          "name": "websoc_course_year_quarter_is_ge_5a_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_5a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_5b_index": {
+          "name": "websoc_course_year_quarter_is_ge_5b_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_5b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_6_index": {
+          "name": "websoc_course_year_quarter_is_ge_6_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_6",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_7_index": {
+          "name": "websoc_course_year_quarter_is_ge_7_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_7",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_8_index": {
+          "name": "websoc_course_year_quarter_is_ge_8_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_8",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_dept_code_index": {
+          "name": "websoc_course_year_quarter_dept_code_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dept_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_dept_code_course_number_index": {
+          "name": "websoc_course_year_quarter_dept_code_course_number_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dept_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_course_department_id_websoc_department_id_fk": {
+          "name": "websoc_course_department_id_websoc_department_id_fk",
+          "tableFrom": "websoc_course",
+          "tableTo": "websoc_department",
+          "columnsFrom": ["department_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_department": {
+      "name": "websoc_department",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "term",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dept_code": {
+          "name": "dept_code",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dept_name": {
+          "name": "dept_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dept_comment": {
+          "name": "dept_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_code_range_comments": {
+          "name": "section_code_range_comments",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_number_range_comments": {
+          "name": "course_number_range_comments",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "websoc_department_school_id_index": {
+          "name": "websoc_department_school_id_index",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_department_year_quarter_school_id_dept_code_index": {
+          "name": "websoc_department_year_quarter_school_id_dept_code_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dept_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_department_school_id_websoc_school_id_fk": {
+          "name": "websoc_department_school_id_websoc_school_id_fk",
+          "tableFrom": "websoc_department",
+          "tableTo": "websoc_school",
+          "columnsFrom": ["school_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_instructor": {
+      "name": "websoc_instructor",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_location": {
+      "name": "websoc_location",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "building": {
+          "name": "building",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room": {
+          "name": "room",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "websoc_location_building_room_index": {
+          "name": "websoc_location_building_room_index",
+          "columns": [
+            {
+              "expression": "building",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_meta": {
+      "name": "websoc_meta",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_scraped": {
+          "name": "last_scraped",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_dept_scraped": {
+          "name": "last_dept_scraped",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_school": {
+      "name": "websoc_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "term",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_name": {
+          "name": "school_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_comment": {
+          "name": "school_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "websoc_school_year_quarter_school_name_index": {
+          "name": "websoc_school_year_quarter_school_name_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_section": {
+      "name": "websoc_section",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "term",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units": {
+          "name": "units",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "websoc_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructors": {
+          "name": "instructors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetings": {
+          "name": "meetings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_exam_string": {
+          "name": "final_exam_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_exam": {
+          "name": "final_exam",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_num": {
+          "name": "section_num",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_capacity": {
+          "name": "max_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_code": {
+          "name": "section_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_type": {
+          "name": "section_type",
+          "type": "websoc_section_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_requested": {
+          "name": "num_requested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restriction_string": {
+          "name": "restriction_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restriction_a": {
+          "name": "restriction_a",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_b": {
+          "name": "restriction_b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_c": {
+          "name": "restriction_c",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_d": {
+          "name": "restriction_d",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_e": {
+          "name": "restriction_e",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_f": {
+          "name": "restriction_f",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_g": {
+          "name": "restriction_g",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_h": {
+          "name": "restriction_h",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_i": {
+          "name": "restriction_i",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_j": {
+          "name": "restriction_j",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_k": {
+          "name": "restriction_k",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_l": {
+          "name": "restriction_l",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_m": {
+          "name": "restriction_m",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_n": {
+          "name": "restriction_n",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_o": {
+          "name": "restriction_o",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_r": {
+          "name": "restriction_r",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_s": {
+          "name": "restriction_s",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_x": {
+          "name": "restriction_x",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "num_on_waitlist": {
+          "name": "num_on_waitlist",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_waitlist_cap": {
+          "name": "num_waitlist_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_comment": {
+          "name": "section_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_new_only_reserved": {
+          "name": "num_new_only_reserved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_currently_total_enrolled": {
+          "name": "num_currently_total_enrolled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_currently_section_enrolled": {
+          "name": "num_currently_section_enrolled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_cancelled": {
+          "name": "is_cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "\"websoc_section\".\"section_comment\" LIKE '*** CANCELLED ***%'",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "websoc_section_course_id_index": {
+          "name": "websoc_section_course_id_index",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_section_year_quarter_section_code_index": {
+          "name": "websoc_section_year_quarter_section_code_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_section_course_id_websoc_course_id_fk": {
+          "name": "websoc_section_course_id_websoc_course_id_fk",
+          "tableFrom": "websoc_section",
+          "tableTo": "websoc_course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_section_enrollment": {
+      "name": "websoc_section_enrollment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "year": {
+          "name": "year",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "term",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_capacity": {
+          "name": "max_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_currently_total_enrolled": {
+          "name": "num_currently_total_enrolled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_on_waitlist": {
+          "name": "num_on_waitlist",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_waitlist_cap": {
+          "name": "num_waitlist_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_requested": {
+          "name": "num_requested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_new_only_reserved": {
+          "name": "num_new_only_reserved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "websoc_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "websoc_section_enrollment_section_id_index": {
+          "name": "websoc_section_enrollment_section_id_index",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_section_enrollment_section_id_created_at_index": {
+          "name": "websoc_section_enrollment_section_id_created_at_index",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_section_enrollment_section_id_websoc_section_id_fk": {
+          "name": "websoc_section_enrollment_section_id_websoc_section_id_fk",
+          "tableFrom": "websoc_section_enrollment",
+          "tableTo": "websoc_section",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_section_grade": {
+      "name": "websoc_section_grade",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_a_count": {
+          "name": "grade_a_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_b_count": {
+          "name": "grade_b_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_c_count": {
+          "name": "grade_c_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_d_count": {
+          "name": "grade_d_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_f_count": {
+          "name": "grade_f_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_p_count": {
+          "name": "grade_p_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_np_count": {
+          "name": "grade_np_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_w_count": {
+          "name": "grade_w_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_gpa": {
+          "name": "average_gpa",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "websoc_section_grade_section_id_index": {
+          "name": "websoc_section_grade_section_id_index",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_section_grade_section_id_websoc_section_id_fk": {
+          "name": "websoc_section_grade_section_id_websoc_section_id_fk",
+          "tableFrom": "websoc_section_grade",
+          "tableTo": "websoc_section",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "websoc_section_grade_section_id_unique": {
+          "name": "websoc_section_grade_section_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["section_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_section_meeting": {
+      "name": "websoc_section_meeting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_code": {
+          "name": "section_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_index": {
+          "name": "meeting_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_string": {
+          "name": "time_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_is_tba": {
+          "name": "time_is_tba",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "\"websoc_section_meeting\".\"time_string\" LIKE '%TBA%'",
+            "type": "stored"
+          }
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_string": {
+          "name": "days_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meets_monday": {
+          "name": "meets_monday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meets_tuesday": {
+          "name": "meets_tuesday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meets_wednesday": {
+          "name": "meets_wednesday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meets_thursday": {
+          "name": "meets_thursday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meets_friday": {
+          "name": "meets_friday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meets_saturday": {
+          "name": "meets_saturday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meets_sunday": {
+          "name": "meets_sunday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "websoc_section_meeting_section_id_index": {
+          "name": "websoc_section_meeting_section_id_index",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_section_meeting_section_id_websoc_section_id_fk": {
+          "name": "websoc_section_meeting_section_id_websoc_section_id_fk",
+          "tableFrom": "websoc_section_meeting",
+          "tableTo": "websoc_section",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_section_meeting_to_location": {
+      "name": "websoc_section_meeting_to_location",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "websoc_section_meeting_to_location_section_id_index": {
+          "name": "websoc_section_meeting_to_location_section_id_index",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_section_meeting_to_location_location_id_index": {
+          "name": "websoc_section_meeting_to_location_location_id_index",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_section_meeting_to_location_section_id_location_id_index": {
+          "name": "websoc_section_meeting_to_location_section_id_location_id_index",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_section_meeting_to_location_section_id_websoc_section_meeting_id_fk": {
+          "name": "websoc_section_meeting_to_location_section_id_websoc_section_meeting_id_fk",
+          "tableFrom": "websoc_section_meeting_to_location",
+          "tableTo": "websoc_section_meeting",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "websoc_section_meeting_to_location_location_id_websoc_location_id_fk": {
+          "name": "websoc_section_meeting_to_location_location_id_websoc_location_id_fk",
+          "tableFrom": "websoc_section_meeting_to_location",
+          "tableTo": "websoc_location",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_section_to_instructor": {
+      "name": "websoc_section_to_instructor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructor_name": {
+          "name": "instructor_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "websoc_section_to_instructor_section_id_index": {
+          "name": "websoc_section_to_instructor_section_id_index",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_section_to_instructor_instructor_name_index": {
+          "name": "websoc_section_to_instructor_instructor_name_index",
+          "columns": [
+            {
+              "expression": "instructor_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_section_to_instructor_section_id_websoc_section_id_fk": {
+          "name": "websoc_section_to_instructor_section_id_websoc_section_id_fk",
+          "tableFrom": "websoc_section_to_instructor",
+          "tableTo": "websoc_section",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "websoc_section_to_instructor_instructor_name_websoc_instructor_name_fk": {
+          "name": "websoc_section_to_instructor_instructor_name_websoc_instructor_name_fk",
+          "tableFrom": "websoc_section_to_instructor",
+          "tableTo": "websoc_instructor",
+          "columnsFrom": ["instructor_name"],
+          "columnsTo": ["name"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.course_level": {
+      "name": "course_level",
+      "schema": "public",
+      "values": ["LowerDiv", "UpperDiv", "Graduate"]
+    },
+    "public.division": {
+      "name": "division",
+      "schema": "public",
+      "values": ["Undergraduate", "Graduate"]
+    },
+    "public.term": {
+      "name": "term",
+      "schema": "public",
+      "values": ["Fall", "Winter", "Spring", "Summer1", "Summer10wk", "Summer2"]
+    },
+    "public.websoc_section_type": {
+      "name": "websoc_section_type",
+      "schema": "public",
+      "values": [
+        "Act",
+        "Col",
+        "Dis",
+        "Fld",
+        "Lab",
+        "Lec",
+        "Qiz",
+        "Res",
+        "Sem",
+        "Stu",
+        "Tap",
+        "Tut"
+      ]
+    },
+    "public.websoc_status": {
+      "name": "websoc_status",
+      "schema": "public",
+      "values": ["OPEN", "Waitl", "FULL", "NewOnly"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1730401838437,
       "tag": "0003_refactor",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1730675191549,
+      "tag": "0004_enhance_scraper",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -11,6 +11,7 @@ async function main() {
   if (!url) throw new Error("Database URL not provided. Please check your .env file.");
   const db = database(url);
   await migrate(db, { migrationsFolder: join(__dirname, "../migrations") });
+  await db.$client.end({ timeout: 5 });
   exit(0);
 }
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -660,5 +660,8 @@ export const studyRoomSlot = pgTable(
     end: timestamp("end", { mode: "date" }).notNull(),
     isAvailable: boolean("is_available").notNull(),
   },
-  (table) => [index().on(table.studyRoomId)],
+  (table) => [
+    index().on(table.studyRoomId),
+    uniqueIndex().on(table.studyRoomId, table.start, table.end),
+  ],
 );

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -161,13 +161,14 @@ export type SectionType = (typeof websocSectionTypes)[number];
 export const websocMeta = pgTable("websoc_meta", {
   name: varchar("name").primaryKey(),
   lastScraped: timestamp("last_scraped", { mode: "date", withTimezone: true }).notNull(),
+  lastDeptScraped: varchar("last_dept_scraped"),
 });
 
 export const websocSchool = pgTable(
   "websoc_school",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).notNull(),
     year: varchar("year").notNull(),
     quarter: term("quarter").notNull(),
     schoolName: varchar("school_name").notNull(),
@@ -183,7 +184,7 @@ export const websocDepartment = pgTable(
     schoolId: uuid("school_id")
       .references(() => websocSchool.id)
       .notNull(),
-    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).notNull(),
     year: varchar("year").notNull(),
     quarter: term("quarter").notNull(),
     deptCode: varchar("dept_code").notNull(),
@@ -210,7 +211,7 @@ export const websocCourse = pgTable(
       .generatedAlwaysAs(
         (): SQL => sql`REPLACE(${websocCourse.deptCode}, ' ', '') || ${websocCourse.courseNumber}`,
       ),
-    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).notNull(),
     year: varchar("year").notNull(),
     quarter: term("quarter").notNull(),
     schoolName: varchar("school_name").notNull(),
@@ -269,7 +270,7 @@ export const websocSection = pgTable(
     courseId: uuid("course_id")
       .references(() => websocCourse.id)
       .notNull(),
-    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).notNull(),
     year: varchar("year").notNull(),
     quarter: term("quarter").notNull(),
     units: varchar("units").notNull(),
@@ -327,7 +328,7 @@ export const websocSectionMeeting = pgTable(
     sectionId: uuid("section_id")
       .references(() => websocSection.id)
       .notNull(),
-    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).notNull(),
     sectionCode: integer("section_code").notNull(),
     meetingIndex: integer("meeting_index").notNull(),
     timeString: varchar("time_string").notNull(),
@@ -352,7 +353,7 @@ export const websocLocation = pgTable(
   "websoc_location",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).notNull(),
     building: varchar("building").notNull(),
     room: varchar("room").notNull(),
   },
@@ -361,7 +362,7 @@ export const websocLocation = pgTable(
 
 export const websocInstructor = pgTable("websoc_instructor", {
   name: varchar("name").primaryKey(),
-  updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).notNull(),
 });
 
 export const websocSectionToInstructor = pgTable(
@@ -461,7 +462,7 @@ export const course = pgTable(
   "course",
   {
     id: varchar("id").primaryKey(),
-    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).notNull(),
     department: varchar("department").notNull(),
     departmentAlias: varchar("department_alias"),
     courseNumber: varchar("course_number").notNull(),


### PR DESCRIPTION
## Description

Changes to the study room scraper:
- Update database schema to ensure uniqueness of each (study room ID, start, end) tuple. This resolves the issue of that table ballooning to many millions of rows.

Changes to the WebSoc scraper:
- Remove the `DEFAULT NOW` directive for `updated_at` columns to ensure it will be updated by the scraper on an upsert.
- Add a column to the `websoc_meta` table that tracks the last department that was scraped successfully. If this column is not null for any term eligible to be scraped, the scraper will prioritize that term and start where the scraper left off.

Misc fixes:
- Explicitly close the connection upon scraper/migration termination to avoid possible deadlocks.

## Related Issue

Closes #4.

## How Has This Been Tested?

For the study location scraper:
- Run scraper once locally.
- Run `SELECT COUNT(1) FROM study_room_slot` on local dev db.
- Run scraper again.
- Run the above query again and verify that the number is the same, or close to the same. It may differ if run before/after the half-hour mark, since that's usually when additional availability is revealed.

For the WebSoc scraper:
- Run scraper once locally.
- Ctrl-C it before it finishes a full scrape.
- Run scraper again and verify that it picks up where you stopped it last.
- Note the value of the `updated_at` column for an arbitrary row belonging to the term.
- Run scraper again.
- Verify that the `updated_at` column was updated properly.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
