### PR TITLE
feat(search): implement resultType flag

### DIFF
--- a/apps/api/src/schema/search.ts
+++ b/apps/api/src/schema/search.ts
@@ -9,6 +9,7 @@ export const searchQuerySchema = z.object({
     .default(100)
     .refine((x) => x <= 100, "Page size must be smaller than 100"),
   skip: z.coerce.number().default(0),
+  resultType: z.union([z.literal("course"), z.literal("instructor")]).optional(),
 });
 
 export const searchResultSchema = z.discriminatedUnion("type", [

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -110,7 +110,7 @@ export class SearchService {
         id: instructor.ucinetid,
         rank: sql`TS_RANK(${INSTRUCTORS_WEIGHTS}, ${query})`.mapWith(Number),
       })
-      .from(course)
+      .from(instructor)
       .where(sql`${INSTRUCTORS_WEIGHTS} @@ ${query}`)
       .offset(input.skip)
       .limit(input.take)

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -6,7 +6,7 @@ import type {
 } from "$schema";
 import type { z } from "@hono/zod-openapi";
 import type { database } from "@packages/db";
-import { inArray, sql } from "@packages/db/drizzle";
+import { asc, desc, inArray, sql } from "@packages/db/drizzle";
 import { unionAll } from "@packages/db/drizzle-pg";
 import { course, instructor } from "@packages/db/schema";
 import { getFromMapOrThrow } from "@packages/stdlib";
@@ -33,7 +33,7 @@ function splitAtLastNumber(s: string): string {
   const i = Array.from(s.matchAll(/\d+/g))
     .map((x) => x.index)
     .slice(-1)[0];
-  return i === undefined ? s : `${s.slice(0, i)} ${s.slice(i)}`.replaceAll(/ {2,}/g, " ");
+  return (i === undefined ? s : `${s.slice(0, i)} ${s.slice(i)}`).replaceAll(/ {2,}/g, " ");
 }
 
 const toQuery = (query: string) =>
@@ -48,7 +48,91 @@ export class SearchService {
     private readonly instructorsService: InstructorsService,
   ) {}
 
+  private async courseMappingFromResults(results: Map<string, number>) {
+    return await this.coursesService
+      .getCoursesRaw({
+        where: inArray(course.id, Array.from(results.keys())),
+        limit: results.size,
+      })
+      .then((courses) =>
+        courses.reduce(
+          (acc, course) => acc.set(course.id, course),
+          new Map<string, z.infer<typeof courseSchema>>(),
+        ),
+      );
+  }
+
+  private async instructorMappingFromResults(results: Map<string, number>) {
+    return await this.instructorsService
+      .getInstructorsRaw({
+        where: inArray(instructor.ucinetid, Array.from(results.keys())),
+        limit: results.size,
+      })
+      .then((instructors) =>
+        instructors.reduce(
+          (acc, instructor) => acc.set(instructor.ucinetid, instructor),
+          new Map<string, z.infer<typeof instructorSchema>>(),
+        ),
+      );
+  }
+
+  private async doSearchForCourses(
+    input: SearchServiceInput,
+  ): Promise<z.infer<typeof searchResultSchema>[]> {
+    const query = toQuery(input.query);
+    const results = await this.db
+      .select({
+        id: course.id,
+        rank: sql`TS_RANK(${COURSES_WEIGHTS}, ${query})`.mapWith(Number),
+      })
+      .from(course)
+      .where(sql`${COURSES_WEIGHTS} @@ ${query}`)
+      .offset(input.skip)
+      .limit(input.take)
+      .orderBy((t) => [desc(t.rank), asc(t.id)])
+      .then((rows) =>
+        rows.reduce((acc, row) => acc.set(row.id, row.rank), new Map<string, number>()),
+      );
+    const courses = await this.courseMappingFromResults(results);
+    return Array.from(results.entries()).map(([key, rank]) => ({
+      type: "course",
+      result: getFromMapOrThrow(courses, key),
+      rank,
+    }));
+  }
+
+  private async doSearchForInstructors(
+    input: SearchServiceInput,
+  ): Promise<z.infer<typeof searchResultSchema>[]> {
+    const query = toQuery(input.query);
+    const results = await this.db
+      .select({
+        id: instructor.ucinetid,
+        rank: sql`TS_RANK(${INSTRUCTORS_WEIGHTS}, ${query})`.mapWith(Number),
+      })
+      .from(course)
+      .where(sql`${INSTRUCTORS_WEIGHTS} @@ ${query}`)
+      .offset(input.skip)
+      .limit(input.take)
+      .orderBy((t) => [desc(t.rank), asc(t.id)])
+      .then((rows) =>
+        rows.reduce((acc, row) => acc.set(row.id, row.rank), new Map<string, number>()),
+      );
+    const instructors = await this.instructorMappingFromResults(results);
+    return Array.from(results.entries()).map(([key, rank]) => ({
+      type: "instructor",
+      result: getFromMapOrThrow(instructors, key),
+      rank,
+    }));
+  }
+
   async doSearch(input: SearchServiceInput): Promise<z.infer<typeof searchResultSchema>[]> {
+    if (input.resultType === "course") {
+      return this.doSearchForCourses(input);
+    }
+    if (input.resultType === "instructor") {
+      return this.doSearchForInstructors(input);
+    }
     const query = toQuery(input.query);
     const results = await unionAll(
       this.db
@@ -71,42 +155,22 @@ export class SearchService {
       .then((rows) =>
         rows.reduce((acc, row) => acc.set(row.id, row.rank), new Map<string, number>()),
       );
-    const courses = await this.coursesService
-      .getCoursesRaw({
-        where: inArray(course.id, Array.from(results.keys())),
-        limit: results.size,
-      })
-      .then((courses) =>
-        courses.reduce(
-          (acc, course) => acc.set(course.id, course),
-          new Map<string, z.infer<typeof courseSchema>>(),
-        ),
-      );
-    const instructors = await this.instructorsService
-      .getInstructorsRaw({
-        where: inArray(instructor.ucinetid, Array.from(results.keys())),
-        limit: results.size,
-      })
-      .then((instructors) =>
-        instructors.reduce(
-          (acc, instructor) => acc.set(instructor.ucinetid, instructor),
-          new Map<string, z.infer<typeof instructorSchema>>(),
-        ),
-      );
-    return Array.from(results.keys())
-      .map((key) =>
+    const courses = await this.courseMappingFromResults(results);
+    const instructors = await this.instructorMappingFromResults(results);
+    return Array.from(results.entries())
+      .map(([key, rank]) =>
         courses.has(key)
           ? {
               key,
               type: "course" as const,
               result: getFromMapOrThrow(courses, key),
-              rank: getFromMapOrThrow(results, key),
+              rank,
             }
           : {
               key,
               type: "instructor" as const,
               result: getFromMapOrThrow(instructors, key),
-              rank: getFromMapOrThrow(results, key),
+              rank,
             },
       )
       .toSorted((a, b) => {


### PR DESCRIPTION
## Description

Add the `resultType` flag that dictates what types of results are returned by the search endpoint. Can be `course` or `instructor`. Behavior is the same as the endpoint currently if not provided.

## How Has This Been Tested?

Tested locally with queries using the new flag.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
