### PR TITLE
feat: batch endpoints for courses/instructors

### DIFF
--- a/apps/api/src/graphql/resolvers/courses.ts
+++ b/apps/api/src/graphql/resolvers/courses.ts
@@ -16,5 +16,9 @@ export const coursesResolvers = {
       const service = new CoursesService(db);
       return await service.getCourses(coursesQuerySchema.parse(args.query));
     },
+    batchCourses: async (_: unknown, { ids }: { ids: string[] }, { db }: GraphQLContext) => {
+      const service = new CoursesService(db);
+      return await service.batchGetCourses(ids);
+    },
   },
 };

--- a/apps/api/src/graphql/resolvers/instructors.ts
+++ b/apps/api/src/graphql/resolvers/instructors.ts
@@ -18,5 +18,13 @@ export const instructorsResolvers = {
       const service = new InstructorsService(db);
       return await service.getInstructors(instructorsQuerySchema.parse(args.query));
     },
+    batchInstructors: async (
+      _: unknown,
+      { ucinetids }: { ucinetids: string[] },
+      { db }: GraphQLContext,
+    ) => {
+      const service = new InstructorsService(db);
+      return await service.batchGetInstructors(ucinetids);
+    },
   },
 };

--- a/apps/api/src/graphql/schema/courses.ts
+++ b/apps/api/src/graphql/schema/courses.ts
@@ -52,5 +52,6 @@ input CoursesQuery {
 extend type Query {
     course(id: String!): Course!
     courses(query: CoursesQuery!): [Course!]!
+    batchCourses(ids: [String!]!): [Course!]!
 }
 `;

--- a/apps/api/src/graphql/schema/instructors.ts
+++ b/apps/api/src/graphql/schema/instructors.ts
@@ -37,5 +37,6 @@ input InstructorsQuery {
 extend type Query {
     instructor(ucinetid: String!): Instructor!
     instructors(query: InstructorsQuery!): [Instructor!]!
+    batchInstructors(ucinetids: [String!]!): [Instructor!]!
 }
 `;

--- a/apps/api/src/schema/courses.ts
+++ b/apps/api/src/schema/courses.ts
@@ -41,6 +41,10 @@ export const coursesPathSchema = z.object({
     .openapi({ param: { name: "id", in: "path" } }),
 });
 
+export const batchCoursesQuerySchema = z.object({
+  ids: z.string().transform((xs) => xs.split(",")),
+});
+
 export const coursesQuerySchema = z.object({
   department: z.string().optional(),
   courseNumber: z.string().optional(),

--- a/apps/api/src/schema/courses.ts
+++ b/apps/api/src/schema/courses.ts
@@ -42,7 +42,10 @@ export const coursesPathSchema = z.object({
 });
 
 export const batchCoursesQuerySchema = z.object({
-  ids: z.string().transform((xs) => xs.split(",")),
+  ids: z
+    .string({ message: "Parameter 'ids' is required" })
+    .transform((xs) => xs.split(","))
+    .openapi({ example: "COMPSCI161,COMPSCI162" }),
 });
 
 export const coursesQuerySchema = z.object({

--- a/apps/api/src/schema/instructors.ts
+++ b/apps/api/src/schema/instructors.ts
@@ -6,6 +6,10 @@ export const instructorsPathSchema = z.object({
     .openapi({ param: { name: "ucinetid", in: "path" } }),
 });
 
+export const batchInstructorsQuerySchema = z.object({
+  ucinetids: z.string().transform((xs) => xs.split(",")),
+});
+
 export const instructorsQuerySchema = z.object({
   nameContains: z.string().optional(),
   titleContains: z.string().optional(),

--- a/apps/api/src/schema/instructors.ts
+++ b/apps/api/src/schema/instructors.ts
@@ -7,7 +7,10 @@ export const instructorsPathSchema = z.object({
 });
 
 export const batchInstructorsQuerySchema = z.object({
-  ucinetids: z.string().transform((xs) => xs.split(",")),
+  ucinetids: z
+    .string({ message: "Parameter 'ucinetids' is required" })
+    .transform((xs) => xs.split(","))
+    .openapi({ example: "mikes,klefstad" }),
 });
 
 export const instructorsQuerySchema = z.object({

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -6,7 +6,7 @@ import type {
 } from "$schema";
 import type { z } from "@hono/zod-openapi";
 import type { database } from "@packages/db";
-import { asc, desc, inArray, sql } from "@packages/db/drizzle";
+import { asc, desc, sql } from "@packages/db/drizzle";
 import { unionAll } from "@packages/db/drizzle-pg";
 import { course, instructor } from "@packages/db/schema";
 import { getFromMapOrThrow } from "@packages/stdlib";
@@ -58,10 +58,7 @@ export class SearchService {
 
   private async courseMappingFromResults(results: Map<string, number>) {
     return await this.coursesService
-      .getCoursesRaw({
-        where: inArray(course.id, Array.from(results.keys())),
-        limit: results.size,
-      })
+      .batchGetCourses(Array.from(results.keys()))
       .then((courses) =>
         courses.reduce(
           (acc, course) => acc.set(course.id, course),
@@ -72,10 +69,7 @@ export class SearchService {
 
   private async instructorMappingFromResults(results: Map<string, number>) {
     return await this.instructorsService
-      .getInstructorsRaw({
-        where: inArray(instructor.ucinetid, Array.from(results.keys())),
-        limit: results.size,
-      })
+      .batchGetInstructors(Array.from(results.keys()))
       .then((instructors) =>
         instructors.reduce(
           (acc, instructor) => acc.set(instructor.ucinetid, instructor),


### PR DESCRIPTION
## Description

Add support for fetching courses/instructors in a bulk, given a set of IDs.

## Motivation and Context

We have been able to support batch queries for a long time but have never done so (mostly due to my poor planning). This should remove the need for consumers to query our API _N_ times for _N_ things, if they already know exactly what they want.

## How Has This Been Tested?

Tested locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
