### PR TITLE
feat!: return count in search response

### DIFF
--- a/apps/api/src/graphql/schema/search.ts
+++ b/apps/api/src/graphql/schema/search.ts
@@ -1,9 +1,14 @@
 export const searchSchema = `#graphql
 union CourseOrInstructor = Course | Instructor
 
-type SearchResponse @cacheControl(maxAge: 86400) {
+type SearchResult @cacheControl(maxAge: 86400) {
     result: CourseOrInstructor!
     rank: Float!
+}
+
+type SearchResponse {
+    count: Float!
+    results: [SearchResult!]!
 }
 
 input SearchQuery {
@@ -13,6 +18,6 @@ input SearchQuery {
 }
 
 extend type Query {
-    search(query: SearchQuery!): [SearchResponse!]!
+    search(query: SearchQuery!): SearchResponse!
 }
 `;

--- a/apps/api/src/rest/routes/search.ts
+++ b/apps/api/src/rest/routes/search.ts
@@ -1,11 +1,11 @@
 import { defaultHook } from "$hooks";
 import { productionCache } from "$middleware";
-import { errorSchema, responseSchema, searchQuerySchema, searchResultSchema } from "$schema";
+import { accessController } from "$middleware";
+import { errorSchema, responseSchema, searchQuerySchema, searchResponseSchema } from "$schema";
 import { CoursesService, InstructorsService, SearchService } from "$services";
 import type { Bindings } from "$types/bindings";
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
 import { database } from "@packages/db";
-import { accessController } from "../../middleware/access-controller.ts";
 
 const searchRouter = new OpenAPIHono<{ Bindings: Bindings }>({ defaultHook });
 
@@ -19,7 +19,7 @@ const searchRoute = createRoute({
   description: "Retrieves course/instructor results for the given search query.",
   responses: {
     200: {
-      content: { "application/json": { schema: responseSchema(searchResultSchema.array()) } },
+      content: { "application/json": { schema: responseSchema(searchResponseSchema) } },
       description: "Successful operation",
     },
     422: {
@@ -43,10 +43,7 @@ searchRouter.openapi(searchRoute, async (c) => {
   const query = c.req.valid("query");
   const db = database(c.env.DB.connectionString);
   const service = new SearchService(db, new CoursesService(db), new InstructorsService(db));
-  return c.json(
-    { ok: true, data: searchResultSchema.array().parse(await service.doSearch(query)) },
-    200,
-  );
+  return c.json({ ok: true, data: searchResponseSchema.parse(await service.doSearch(query)) }, 200);
 });
 
 export { searchRouter };

--- a/apps/api/src/schema/search.ts
+++ b/apps/api/src/schema/search.ts
@@ -24,3 +24,8 @@ export const searchResultSchema = z.discriminatedUnion("type", [
     rank: z.number(),
   }),
 ]);
+
+export const searchResponseSchema = z.object({
+  count: z.number(),
+  results: searchResultSchema.array(),
+});


### PR DESCRIPTION
## Description
Return the total matched result count in the search response.

## Motivation and Context
Required for PeterPortal integration since they expect a total result count for pagination purposes.

## How Has This Been Tested?
Tested locally, verified that performance loss from pagination in JS is negligible (based on #23).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
