### PR TITLE
feat: properly type prerequisite tree

### DIFF
--- a/apps/api/src/rest/routes/courses.ts
+++ b/apps/api/src/rest/routes/courses.ts
@@ -6,6 +6,8 @@ import {
   coursesPathSchema,
   coursesQuerySchema,
   errorSchema,
+  prerequisiteSchema,
+  prerequisiteTreeSchema,
   responseSchema,
 } from "$schema";
 import { CoursesService } from "$services";
@@ -14,6 +16,9 @@ import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
 import { database } from "@packages/db";
 
 const coursesRouter = new OpenAPIHono<{ Bindings: Bindings }>({ defaultHook });
+
+coursesRouter.openAPIRegistry.register("prereq", prerequisiteSchema);
+coursesRouter.openAPIRegistry.register("prereqTree", prerequisiteTreeSchema);
 
 const batchCoursesRoute = createRoute({
   summary: "Retrieve courses with IDs",


### PR DESCRIPTION
## Description

Revert `prerequisiteTreeSchema` to what it was originally. Also, override the OpenAPI metadata on it so it doesn't cause any errors, and set the metadata properly so consumers can receive the correct type data.

Honestly this was a lot less involved than I expected.

## Related Issue

Closes #28.

## Motivation and Context

Now we won't have to hardcode the prereq tree type in the API's consumers.

## How Has This Been Tested?
- Run dev server locally.
- Use [`openapi-typescript`](https://github.com/openapi-ts/openapi-typescript) to generate a types file from the dev server.
- Paste the following snippet into another TS file and play around with it, ensuring that the `PrerequisiteTree` type behaves as expected.
```ts
// assuming the output is named "anteater-api-types.ts"
import { components } from "./anteater-api-types";

type PrerequisiteTree = components["schemas"]["prereqTree"];
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
