### PR TITLE
feat(larc-scraper): delete older entries

### DIFF
--- a/apps/data-pipeline/larc-scraper/src/lib.ts
+++ b/apps/data-pipeline/larc-scraper/src/lib.ts
@@ -1,8 +1,7 @@
 import type { database } from "@packages/db";
 import { and, eq } from "@packages/db/drizzle";
-import { type Term, larcSection } from "@packages/db/schema";
-import { websocCourse } from "@packages/db/schema";
-import { conflictUpdateSetAllCols } from "@packages/db/utils";
+import type { Term } from "@packages/db/schema";
+import { larcSection, websocCourse } from "@packages/db/schema";
 import { sleep } from "@packages/stdlib";
 import { load } from "cheerio";
 import { fetch } from "cross-fetch";
@@ -141,13 +140,11 @@ export async function doScrape(db: ReturnType<typeof database>) {
       if (!courseId) {
         continue;
       }
+      await tx.delete(larcSection).where(eq(larcSection.courseId, courseId));
       await tx
         .insert(larcSection)
         .values(v.map((x) => ({ ...x, courseId })))
-        .onConflictDoUpdate({
-          target: larcSection.id,
-          set: conflictUpdateSetAllCols(larcSection),
-        });
+        .onConflictDoNothing();
     }
   });
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Deletes existing entries in the LARC section table on scrape.

## Related Issue
Closes #42.

## Motivation and Context

Ensures section data always reflects the latest state of the LARC site and also ensures no duplicates are present.

## How Has This Been Tested?

Tested locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
