### PR TITLE
fix(websoc): graphql terms actually transmitted

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,6 +41,7 @@ Previous Project Leads are not included in this list.
 - Kirby Ammari ([@kirbster6](https://github.com/kirbster6))
 - Yizhen Liu ([@imliuyzh](https://github.com/imliuyzh))
 - Jordan Yee ([@jordany33](https://github.com/jordany33))
+- Dante Dam ([@laggycomputer](https://github.com/laggycomputer))
 - Minh Nguyen ([@MinhxNguyen7](https://github.com/MinhxNguyen7))
 - Nathan Nguyen ([@nathantoannguyen](https://github.com/nathantoannguyen))
 - Pranav Reddy ([@pranavmreddy](https://github.com/pranavmreddy))

--- a/apps/api/src/graphql/resolvers/websoc.ts
+++ b/apps/api/src/graphql/resolvers/websoc.ts
@@ -10,7 +10,7 @@ export const websocResolvers = {
     },
     terms: async (_: unknown, __: unknown, { db }: GraphQLContext) => {
       const service = new WebsocService(db);
-      await service.getAllTerms();
+      return await service.getAllTerms();
     },
   },
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix the bug in #52 by actually returning the fetched result from Postgres.
A single `return` is added.

<!--- Describe your changes in detail -->

## Related Issue

Fixes #52.

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

See above.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Tested on a local deployment.
Postman was used to verify fix was effective.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Aforementioned query now works locally:

![Screenshot_20241212_145043](https://github.com/user-attachments/assets/9d34aeed-4e77-410b-b3d1-10f12e117406)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
