### PR TITLE
fix(week): correct parsing of graphql day

### DIFF
--- a/apps/api/src/schema/week.ts
+++ b/apps/api/src/schema/week.ts
@@ -5,38 +5,24 @@ const isLeap = (x: number) => x % 4 === 0 && (x % 100 === 0 ? x % 400 === 0 : tr
 
 export const weekQuerySchema = z
   .object({
-    year: z
-      .string()
-      .length(4, { message: "Parameter 'year' must have length 4" })
-      .refine((x) => !Number.isNaN(Number.parseInt(x, 10)), {
-        message: "Parameter 'year' must be an integer",
+    year: z.coerce
+      .number()
+      .refine((x) => x.toString().length === 4, { message: "Parameter 'year' must have length 4" })
+      .openapi({ example: 2024 })
+      .optional(),
+    month: z.coerce
+      .number()
+      .refine((x) => 1 <= x && x <= 12, {
+        message: "Parameter 'month' must be an integer between 1 and 12",
       })
-      .transform((x) => Number.parseInt(x, 10))
-      .openapi({ example: "2024" })
+      .openapi({ example: 9 })
       .optional(),
-    month: z
-      .string()
-      .refine(
-        (x) => {
-          const n = Number.parseInt(x, 10);
-          return !Number.isNaN(n) && 1 <= n && n <= 12;
-        },
-        { message: "Parameter 'month' must be an integer between 1 and 12" },
-      )
-      .transform((x) => Number.parseInt(x, 10))
-      .openapi({ example: "9" })
-      .optional(),
-    day: z
-      .string()
-      .refine(
-        (x) => {
-          const n = Number.parseInt(x, 10);
-          return !Number.isNaN(n) && 1 <= n && n <= 31;
-        },
-        { message: "Parameter 'day' must be an integer between 1 and 31" },
-      )
-      .transform((x) => Number.parseInt(x, 10))
-      .openapi({ example: "30" })
+    day: z.coerce
+      .number()
+      .refine((x) => 1 <= x && x <= 31, {
+        message: "Parameter 'day' must be an integer between 1 and 31",
+      })
+      .openapi({ example: 30 })
       .optional(),
   })
   .refine(({ year, month, day }) => (year && month && day) || (!year && !month && !day), {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Corrects schema to allow passing of year, month, and date from GraphQL for week information.

Instead of accepting a string and manually calling `parseInt` to parse it, we use Zod's `z.coerce.number()`.
`z.number()` is unacceptable since this would break REST, where the arguments arrive as strings.

## Related Issue

Fixes #54.

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Fixes an active production bug.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Tested on a local deployment. Parity was ensured between REST and GraphQL.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
GraphQL is working (the goal of this PR):
![Screenshot_20241212_155454](https://github.com/user-attachments/assets/bd0688cb-436a-4c67-a846-3b579ddc1cad)


REST is working as previously:
![Screenshot_20241212_155433](https://github.com/user-attachments/assets/88f80c95-2c14-4f52-9959-df274ec86640)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
