### PR TITLE
fix(search): count is a nonnegative int

### DIFF
--- a/apps/api/src/graphql/schema/search.ts
+++ b/apps/api/src/graphql/schema/search.ts
@@ -7,7 +7,7 @@ type SearchResult @cacheControl(maxAge: 86400) {
 }
 
 type SearchResponse {
-    count: Float!
+    count: Int!
     results: [SearchResult!]!
 }
 

--- a/apps/api/src/schema/search.ts
+++ b/apps/api/src/schema/search.ts
@@ -26,6 +26,6 @@ export const searchResultSchema = z.discriminatedUnion("type", [
 ]);
 
 export const searchResponseSchema = z.object({
-  count: z.number(),
+  count: z.number().int().nonnegative(),
   results: searchResultSchema.array(),
 });


### PR DESCRIPTION
## Description

Retype the type of the count property on the search for instructor/course endpoint as an integer.

## Related Issue

Resolves #56.

## Motivation and Context

As explained in the issue, this is the correct type for this value from a mathematical standpoint.
This is technically a breaking change but:
* It only affects users where integers and floats are not the same (i.e. not JS/TS).
* It only affects people who somehow depended on incorrect behavior.

## How Has This Been Tested?

Local testing was done to ensure neither GraphQL nor REST are broken by this change.
Note that token checks were disabled in this local deployment to simplify local testing.

## Screenshots (if appropriate):

Observe that Postman introspects the new type correctly and the endpoint works as expected:
![image](https://github.com/user-attachments/assets/2be56f84-201c-406e-a894-7551cb70bb6d)

REST continues to work:
![Screenshot_20241216_154750](https://github.com/user-attachments/assets/b3130e60-7025-40a1-acf4-2700161be8e7)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
