### PR TITLE
fix: excludePNP parsing for GraphQL

### DIFF
--- a/apps/api/src/schema/grades.ts
+++ b/apps/api/src/schema/grades.ts
@@ -37,7 +37,7 @@ export const gradesQuerySchema = z.object({
     .optional()
     .or(z.literal("ANY"))
     .transform((x) => (x === "ANY" ? undefined : x)),
-  excludePNP: z
+  excludePNP: z.coerce
     .string()
     .optional()
     .transform((x) => x === "true"),


### PR DESCRIPTION
## Description

As specified in the issue, `excludePNP` is broken for GraphQL grades endpoints. Zod expects a string, which is impossible when schema expects boolean. Fixed by coercing to string before parsing.

`z.coerce.boolean()` is unacceptable since `Boolean("false") === true` which is not what we want.

## Related Issue

Fixes #62.

## Motivation and Context

i just wanna use API man

## How Has This Been Tested?

Tested with Postman on a local deployment.

## Screenshots (if appropriate):

![Screenshot_20241223_113903](https://github.com/user-attachments/assets/f848a918-4307-49be-aced-00168a8efcd7)

Schema validation still works, of course:
![image](https://github.com/user-attachments/assets/e3091f50-b418-4a54-a082-7874504c9e49)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
