### PR TITLE
fix(grades): missing join broke aggregateGradesByCourse

### DIFF
--- a/apps/api/src/services/grades.ts
+++ b/apps/api/src/services/grades.ts
@@ -321,6 +321,10 @@ export class GradesService {
       .from(websocCourse)
       .innerJoin(websocSection, eq(websocSection.courseId, websocCourse.id))
       .innerJoin(websocSectionGrade, eq(websocSectionGrade.sectionId, websocSection.id))
+      .leftJoin(
+        websocSectionToInstructor,
+        eq(websocSection.id, websocSectionToInstructor.sectionId),
+      )
       .groupBy(websocCourse.deptCode, websocCourse.courseNumber)
       .where(buildQuery(input));
   }


### PR DESCRIPTION
## Description

As described in analysis on the linked issue, add a missing join to prevent `aggregateGradesByCourse` from failing when passing an instructor to filter by.

## Related Issue

Fixes #70.

## Motivation and Context

Fixes endpoint failure as described in linked issue.

## How Has This Been Tested?

REST and GraphQL were both examined on a local deployment, following the reproduction steps from the linked issue. The issue is no longer present.

## Screenshots (if appropriate):

REST is working:
![Screenshot_20250109_002318](https://github.com/user-attachments/assets/6827853c-bc0d-4d73-9753-cde431e980a8)

GraphQL is working:
![Screenshot_20250109_002223](https://github.com/user-attachments/assets/40aa6020-e874-46b8-a070-17087da7ffdc)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
