### PR TITLE
fix(study-rooms): specify and serve UCI timezone for slots

### DIFF
--- a/apps/api/src/schema/study-rooms.ts
+++ b/apps/api/src/schema/study-rooms.ts
@@ -2,8 +2,8 @@ import { z } from "@hono/zod-openapi";
 
 export const slotSchema = z.object({
   studyRoomId: z.string(),
-  start: z.string().datetime({ offset: true }),
-  end: z.string().datetime({ offset: true }),
+  start: z.string().datetime({ offset: true }).openapi({ example: "2021-01-06T08:00:00-08:00" }),
+  end: z.string().datetime({ offset: true }).openapi({ example: "2021-01-06T08:30:00-08:00" }),
   isAvailable: z.boolean(),
 });
 

--- a/apps/data-pipeline/study-location-scraper/src/lib.ts
+++ b/apps/data-pipeline/study-location-scraper/src/lib.ts
@@ -1,5 +1,5 @@
 import type { database } from "@packages/db";
-import { lt } from "@packages/db/drizzle";
+import { lt, sql } from "@packages/db/drizzle";
 import { studyLocation, studyRoom, studyRoomSlot, studyRoomView } from "@packages/db/schema";
 import { conflictUpdateSetAllCols } from "@packages/db/utils";
 import type { Cheerio, CheerioAPI } from "cheerio";
@@ -245,6 +245,7 @@ export async function doScrape(db: ReturnType<typeof database>) {
   );
   const slotRows = roomRows.flatMap((room) => room.slots);
   await db.transaction(async (tx) => {
+    await tx.execute(sql`SET TIME ZONE 'America/Los_Angeles';`);
     await tx
       .insert(studyLocation)
       .values(locationRows)


### PR DESCRIPTION
## Description

Followup to #75, fixing study room slot times being rendered in Postgres's local timezone.
We simply set the timezone on the connection acquired by the scraper to `America/Los_Angeles`.

## Related Issue

Resolves #84. We both specify the intended behavior from #75 in the example and actually fulfill it.

## Motivation and Context

## How Has This Been Tested?

Tested by setting Postgres's timezone to `America/New_York`, running the scraper, then testing the API request.

## Screenshots (if appropriate):

Despite forcing Postgres's global timezone to change, the timezone is correct since we set it on the session which takes precedence over the global setting:

![Screenshot_20250115_110206](https://github.com/user-attachments/assets/97c1badd-5c8a-44af-9b1c-8daddf03421e)

We know this is effective because setting a different timezone for the scraper's SQL session uses that timezone instead:

![Screenshot_20250115_110404](https://github.com/user-attachments/assets/371a8cda-3751-461b-b2b0-69092e441b55)

So if we force `America/Los_Angeles` on the scraper session, it will give the correct offset regardless of Postgres or system timezone.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
