### PR TITLE
fix(programs): add majors with no specializations

### DIFF
--- a/apps/api/src/services/programs.ts
+++ b/apps/api/src/services/programs.ts
@@ -20,10 +20,12 @@ export class ProgramsService {
         .select({
           id: major.id,
           name: major.name,
-          specializations: sql`array_agg(${specialization.id})`.as("specializations"),
+          specializations: sql`array_remove(array_agg(${specialization.id}), NULL)`.as(
+            "specializations",
+          ),
         })
         .from(major)
-        .innerJoin(specialization, eq(major.id, specialization.majorId))
+        .leftJoin(specialization, eq(major.id, specialization.majorId))
         .groupBy(major.id),
     );
 


### PR DESCRIPTION
## Description

Silly bugfix.

## Related Issue

Fix #98.

## Motivation and Context

just don't have a bug

## How Has This Been Tested?

Tested locally with Postman.

## Screenshots (if appropriate):

Majors with no specializations are now present:
![image](https://github.com/user-attachments/assets/c6d79c58-0e9f-44cf-8878-a00ecb985bd4)

The number of majors in the `major` table is 270. All of them appear in the response:
```
Welcome to Node.js v23.5.0.
Type ".help" for more information.
> const {data} = await fetch("http://localhost:8787/v2/rest/programs/majors").then(r => r.json())
undefined
> data.length
270
> 
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
