### PR TITLE
fix(websoc): store sentinels for null due to quirk

### DIFF
--- a/packages/stdlib/src/int-utils.ts
+++ b/packages/stdlib/src/int-utils.ts
@@ -10,3 +10,8 @@ export const isBaseTenInt = (s: string): boolean =>
  */
 export const baseTenIntOrNull = (s: string): number | null =>
   isBaseTenInt(s) ? Number.parseInt(s, 10) : null;
+
+/**
+ * Convert a nullable `number` to `null` if negative.
+ */
+export const negativeAsNull = (s: number | null): number | null => ((s ?? -1) < 0 ? null : s);


### PR DESCRIPTION
## Description

`conflictUpdateSetAllCols` cannot disambiguate updating a column to `NULL` and deferring to the existing value, causing the issue mentioned below. We fix this by storing a sentinel `-1` and checking for this in the service layer, a minor overhead.

This affects the following columns of `websoc_section` and no other uses of `conflictUpdateSetAllCols` (since those columns are not nullable):
```sql
status, num_on_waitlist, num_waitlist_cap, num_new_only_reserved, num_currently_total_enrolled, num_currently_section_enrolled
```
## Related Issue

Fix #112

## Motivation and Context

anteater api no prod bug challenge

## How Has This Been Tested?

ran REST manually

Sanity check: all sections returned by `fullOnly` for Winter 2025 now correctly report an empty waitlist and waitlist cap.

Second sanity check: no `websoc_section` rows for Winter 2025 have any waitlist count.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
