### PR TITLE
feat(websoc): bisect to handle section chunk overrun

### DIFF
--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -40,7 +40,7 @@ import { load } from "cheerio";
 
 /**
  * WebSoc allows us to scrape up to 900 sections per chunk.
- * This provides a 1% margin of error in case sections magically appear within ranges.
+ * This provides a 1% margin of error in case new sections appear within ranges (which has happened before).
  */
 const SECTIONS_PER_CHUNK = 891;
 
@@ -830,16 +830,9 @@ export async function scrapeTerm(
   } else {
     console.log("Performing chunk-wise scrape.");
     for (let i = 0; i < sectionCodeBounds.length; i += 2) {
-      const lower = sectionCodeBounds[i];
-      const upper = sectionCodeBounds[i + 1] ?? LAST_SECTION_CODE;
-      const sectionCodes = `${lower}-${upper}`;
-      console.log(`Scraping chunk ${sectionCodes}`);
-      const resp = await request(term, {
-        sectionCodes,
-        cancelledCourses: "Include",
-      }).then(normalizeResponse);
-      if (resp.schools.length) await doChunkUpsert(db, term, resp, null);
-      await sleep(1000);
+      const lower = sectionCodeBounds[i] as `${number}`;
+      const upper = (sectionCodeBounds[i + 1] ?? LAST_SECTION_CODE) as `${number}`;
+      await ingestChunk(db, term, lower, upper);
     }
   }
   await scrapeGEsForTerm(db, term);
@@ -851,6 +844,48 @@ export async function scrapeTerm(
       .values(values)
       .onConflictDoUpdate({ target: websocMeta.name, set: values });
   });
+}
+
+export async function ingestChunk(
+  db: ReturnType<typeof database>,
+  term: Term,
+  lower: `${number}`,
+  upper: `${number}`,
+) {
+  const sectionCodes = `${lower}-${upper}`;
+  console.log(`Scraping chunk ${sectionCodes}`);
+  try {
+    const resp = await request(term, {
+      sectionCodes,
+      cancelledCourses: "Include",
+    }).then(normalizeResponse);
+    if (resp.schools.length) await doChunkUpsert(db, term, resp, null);
+    await sleep(1000);
+  } catch (e) {
+    /*
+     assuming network, etc. conditions are fine, we have more than 900 sections here
+     this means we somehow overran our 1% tolerance
+     that's okay; we can be suboptimal this time so we get all the sections that exist.
+     we're going to recompute the chunks at the start of the next scrape,
+     so that one will run optimally, given no such failure occurs again
+
+     we're going to bisect this chunk and try the two halves separately; eventually,
+     we'll have <= 900 valid sections in a chunk and we'll be in the clear
+    */
+    const lowerInt = baseTenIntOrNull(lower) as number;
+    const upperInt = baseTenIntOrNull(upper) as number;
+    const rangeLength = upperInt - lowerInt + 1;
+    if (rangeLength < 900) {
+      // okay, no way this was a chunk overrun
+      throw e;
+    }
+
+    console.log(`Chunk ${sectionCodes} too large; bisecting and trying again...`);
+
+    const middleInt = lowerInt + Math.floor((upperInt - lowerInt) / 2);
+    await ingestChunk(db, term, lower, middleInt.toString().padStart(5, "0") as `${number}`);
+    await ingestChunk(db, term, (middleInt + 1).toString().padStart(5, "0") as `${number}`, upper);
+  }
 }
 
 export async function doScrape(db: ReturnType<typeof database>) {

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -846,7 +846,7 @@ export async function scrapeTerm(
   });
 }
 
-export async function ingestChunk(
+async function ingestChunk(
   db: ReturnType<typeof database>,
   term: Term,
   lower: `${number}`,

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -880,7 +880,7 @@ export async function ingestChunk(
       throw e;
     }
 
-    console.log(`Chunk ${sectionCodes} too large; bisecting and trying again...`);
+    console.log(`Chunk ${sectionCodes} failed (probably too large); bisecting and trying again...`);
 
     const middleInt = lowerInt + Math.floor((upperInt - lowerInt) / 2);
     await ingestChunk(db, term, lower, middleInt.toString().padStart(5, "0") as `${number}`);

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -872,8 +872,8 @@ export async function ingestChunk(
      we're going to bisect this chunk and try the two halves separately; eventually,
      we'll have <= 900 valid sections in a chunk and we'll be in the clear
     */
-    const lowerInt = baseTenIntOrNull(lower) as number;
-    const upperInt = baseTenIntOrNull(upper) as number;
+    const lowerInt = Number.parseInt(lower, 10);
+    const upperInt = Number.parseInt(upper, 10);
     const rangeLength = upperInt - lowerInt + 1;
     if (rangeLength < 900) {
       // okay, no way this was a chunk overrun


### PR DESCRIPTION
## Description

## Related Issue

Execute recommendation in #110.

## Motivation and Context

Currently, when `libwebsoc-next` finds more than 900 sections, it immediately throws.
In the context of our current scraping strategy using chunks of the section space, a chunk thought to contain less than 900 sections may be found (and, in practice, has been found) to actually contain more than 900 sections, causing the scraping of that chunk to fail, crashing the scraper.
A later run would crash too, at the exact same point.
So a violation of our current assumptions is fatal.

## How Has This Been Tested?

Change `SECTIONS_PER_CHUNK` to something greater than 900 (the higher, the more often the failsafe will trigger).
This will simulate more than 900 sections being found in a chunk.

## Screenshots (if appropriate):

Observe in this printout as a chunk is found to be too large and bisected once, which is successful:
```
Chunk 50004-52814 failed (probably too large); bisecting and trying again...
Scraping chunk 50004-51409
Inserted 0 enrollment entries
Scraping chunk 51410-52814
Inserted 0 enrollment entries
```

Observe that this bisection is also recursive and therefore resilient under a pathological case:
```
Scraping chunk 01012-12105
Chunk 01012-12105 failed (probably too large); bisecting and trying again...
Scraping chunk 01012-06558
Chunk 01012-06558 failed (probably too large); bisecting and trying again...
Scraping chunk 01012-03785
Inserted 0 enrollment entries
Scraping chunk 03786-06558
Inserted 0 enrollment entries
Scraping chunk 06559-12105
Inserted 0 enrollment entries
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
