### PR TITLE
feat(dw-scraper): better wildcard handling

### DIFF
--- a/apps/data-pipeline/degreeworks-scraper/src/components/AuditParser.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/AuditParser.ts
@@ -55,12 +55,16 @@ export class AuditParser {
     // "ELECTIVE @" is typically used as a pseudo-course and can be safely ignored.
     if (courseIdLike.match(AuditParser.electiveMatcher)) return [];
     const [department, courseNumber] = courseIdLike.split(" ");
+    if (courseNumber === "@") {
+      // Department-wide wildcards.
+      return this.db.select().from(course).where(eq(course.shortenedDept, department));
+    }
     if (courseNumber.match(AuditParser.wildcardMatcher)) {
       // Wildcard course numbers.
       return await this.db
         .select()
         .from(course)
-        .where(eq(course.department, department))
+        .where(eq(course.shortenedDept, department))
         .then((rows) =>
           rows.filter((x) =>
             x.courseNumber.match(
@@ -76,7 +80,7 @@ export class AuditParser {
       return await this.db
         .select()
         .from(course)
-        .where(eq(course.department, department))
+        .where(eq(course.shortenedDept, department))
         .then((rows) =>
           rows.filter(
             (x) =>

--- a/apps/data-pipeline/degreeworks-scraper/src/components/AuditParser.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/AuditParser.ts
@@ -64,9 +64,7 @@ export class AuditParser {
         .then((rows) =>
           rows.filter((x) =>
             x.courseNumber.match(
-              new RegExp(
-                `^${courseNumber.replace(/@+/g, `.{${[...courseNumber].filter((y) => y === "@").length},}`)}`,
-              ),
+              new RegExp(`^${courseNumber.replace("@@", "\\w{2,}").replace("@", "\\w+")}`),
             ),
           ),
         );

--- a/apps/data-pipeline/degreeworks-scraper/src/components/AuditParser.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/AuditParser.ts
@@ -64,6 +64,7 @@ export class AuditParser {
         .then((rows) =>
           rows.filter((x) =>
             x.courseNumber.match(
+              // we assume @@@ and longer never happen (#122)
               new RegExp(`^${courseNumber.replace("@@", "\\w{2,}").replace("@", "\\w+")}`),
             ),
           ),

--- a/packages/db/migrations/0010_shortened_dept.sql
+++ b/packages/db/migrations/0010_shortened_dept.sql
@@ -1,0 +1,63 @@
+DROP MATERIALIZED VIEW "public"."course_view";--> statement-breakpoint
+ALTER TABLE "course" ADD COLUMN "shortened_dept" varchar GENERATED ALWAYS AS (REPLACE("course"."department", ' ', '')) STORED NOT NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "shortened_dept" ON "course" USING btree ("shortened_dept");--> statement-breakpoint
+CREATE MATERIALIZED VIEW "public"."course_view" AS (select "course"."id", "course"."updated_at", "course"."department", "course"."shortened_dept", "course"."department_alias", "course"."course_number", "course"."course_numeric", "course"."school", "course"."title", "course"."course_level", "course"."min_units", "course"."max_units", "course"."description", "course"."department_name", "course"."prerequisite_tree", "course"."prerequisite_text", "course"."repeatability", "course"."grading_option", "course"."concurrent", "course"."same_as", "course"."restriction", "course"."overlap", "course"."corequisites", "course"."is_ge_1a", "course"."is_ge_1b", "course"."is_ge_2", "course"."is_ge_3", "course"."is_ge_4", "course"."is_ge_5a", "course"."is_ge_5b", "course"."is_ge_6", "course"."is_ge_7", "course"."is_ge_8", "course"."ge_text", 
+        ARRAY_REMOVE(COALESCE(
+          (
+            SELECT ARRAY_AGG(
+              CASE WHEN "prerequisite_course"."id" IS NULL THEN NULL
+              ELSE JSONB_BUILD_OBJECT(
+              'id', "prerequisite_course"."id",
+              'title', "prerequisite_course"."title",
+              'department', "prerequisite_course"."department",
+              'courseNumber', "prerequisite_course"."course_number"
+              )
+              END
+            )
+            FROM "prerequisite"
+            LEFT JOIN "course" "prerequisite_course" ON "prerequisite_course"."id" = "prerequisite"."prerequisite_id"
+            WHERE "prerequisite"."dependency_id" = "course"."id"
+          ),
+        ARRAY[]::JSONB[]), NULL)
+         as "prerequisites", 
+        ARRAY_REMOVE(COALESCE(
+          (
+            SELECT ARRAY_AGG(
+              CASE WHEN "dependency_course"."id" IS NULL THEN NULL
+              ELSE JSONB_BUILD_OBJECT(
+                'id', "dependency_course"."id",
+                'title', "dependency_course"."title",
+                'department', "dependency_course"."department",
+                'courseNumber', "dependency_course"."course_number"
+              )
+              END
+            )
+            FROM "prerequisite" "dependency"
+            LEFT JOIN "course" "dependency_course" ON "dependency_course"."id" = "dependency"."dependency_id"
+            WHERE "dependency"."prerequisite_id" = "course"."id"
+          ),
+        ARRAY[]::JSONB[]), NULL)
+         as "dependencies", 
+          ARRAY_REMOVE(ARRAY_AGG(DISTINCT
+            CASE WHEN "websoc_course"."year" IS NULL THEN NULL
+            ELSE CONCAT("websoc_course"."year", ' ', "websoc_course"."quarter")
+            END
+          ), NULL)
+           as "terms", 
+        ARRAY_REMOVE(COALESCE(ARRAY_AGG(DISTINCT
+          CASE WHEN "instructor"."ucinetid" IS NULL THEN NULL
+          ELSE JSONB_BUILD_OBJECT(
+            'ucinetid', "instructor"."ucinetid",
+            'name', "instructor"."name",
+            'title', "instructor"."title",
+            'email', "instructor"."email",
+            'department', "instructor"."department",
+            'shortenedNames', ARRAY(
+              SELECT "instructor_to_websoc_instructor"."websoc_instructor_name"
+              FROM "instructor_to_websoc_instructor"
+              WHERE "instructor_to_websoc_instructor"."instructor_ucinetid" = "instructor"."ucinetid"
+            )
+          )
+          END
+        ), ARRAY[]::JSONB[]), NULL)
+         as "instructors" from "course" left join "websoc_course" on "websoc_course"."course_id" = "course"."id" left join "websoc_section" on "websoc_section"."course_id" = "websoc_course"."id" left join "websoc_section_to_instructor" on "websoc_section_to_instructor"."section_id" = "websoc_section"."id" left join "websoc_instructor" on "websoc_instructor"."name" = "websoc_section_to_instructor"."instructor_name" left join "instructor_to_websoc_instructor" on "instructor_to_websoc_instructor"."websoc_instructor_name" = "websoc_instructor"."name" left join "instructor" on ("instructor"."ucinetid" = "instructor_to_websoc_instructor"."instructor_ucinetid" and "instructor"."ucinetid" is not null and "instructor"."ucinetid" <> 'student') group by "course"."id");

--- a/packages/db/migrations/meta/0010_snapshot.json
+++ b/packages/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,3380 @@
+{
+  "id": "a60d57cd-09db-46d6-adbc-5f9a78bae0b8",
+  "prevId": "06f18d63-0ea4-4cba-a194-c3ff0514b077",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.calendar_term": {
+      "name": "calendar_term",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "generated": {
+            "as": "\"calendar_term\".\"year\" || ' ' || CASE WHEN \"calendar_term\".\"quarter\" = 'Fall' THEN 'Fall' WHEN \"calendar_term\".\"quarter\" = 'Winter' THEN 'Winter' WHEN \"calendar_term\".\"quarter\" = 'Spring' THEN 'Spring' WHEN \"calendar_term\".\"quarter\" = 'Summer1' THEN 'Summer1' WHEN \"calendar_term\".\"quarter\" = 'Summer10wk' THEN 'Summer10wk' WHEN \"calendar_term\".\"quarter\" = 'Summer2' THEN 'Summer2' ELSE '' END",
+            "type": "stored"
+          }
+        },
+        "year": {
+          "name": "year",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "term",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction_start": {
+          "name": "instruction_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction_end": {
+          "name": "instruction_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finals_start": {
+          "name": "finals_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finals_end": {
+          "name": "finals_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soc_available": {
+          "name": "soc_available",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course": {
+      "name": "course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shortened_dept": {
+          "name": "shortened_dept",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "REPLACE(\"course\".\"department\", ' ', '')",
+            "type": "stored"
+          }
+        },
+        "department_alias": {
+          "name": "department_alias",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_number": {
+          "name": "course_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_numeric": {
+          "name": "course_numeric",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "CASE REGEXP_REPLACE(\"course\".\"course_number\", '\\D', '', 'g') WHEN '' THEN 0 ELSE REGEXP_REPLACE(\"course\".\"course_number\", '\\D', '', 'g')::INTEGER END",
+            "type": "stored"
+          }
+        },
+        "school": {
+          "name": "school",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_level": {
+          "name": "course_level",
+          "type": "course_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_units": {
+          "name": "min_units",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_units": {
+          "name": "max_units",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department_name": {
+          "name": "department_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_tree": {
+          "name": "prerequisite_tree",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_text": {
+          "name": "prerequisite_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repeatability": {
+          "name": "repeatability",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grading_option": {
+          "name": "grading_option",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "concurrent": {
+          "name": "concurrent",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "same_as": {
+          "name": "same_as",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restriction": {
+          "name": "restriction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overlap": {
+          "name": "overlap",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corequisites": {
+          "name": "corequisites",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_1a": {
+          "name": "is_ge_1a",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_1b": {
+          "name": "is_ge_1b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_2": {
+          "name": "is_ge_2",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_3": {
+          "name": "is_ge_3",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_4": {
+          "name": "is_ge_4",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_5a": {
+          "name": "is_ge_5a",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_5b": {
+          "name": "is_ge_5b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_6": {
+          "name": "is_ge_6",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_7": {
+          "name": "is_ge_7",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_8": {
+          "name": "is_ge_8",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ge_text": {
+          "name": "ge_text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "course_search_index": {
+          "name": "course_search_index",
+          "columns": [
+            {
+              "expression": "(\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"id\", '')), 'A') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"department\", '')), 'B') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"department_alias\", '')), 'B') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"course_number\", '')), 'B') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"course_numeric\"::TEXT, '')), 'B') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"title\", '')), 'C') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"description\", '')), 'D')\n)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "shortened_dept": {
+          "name": "shortened_dept",
+          "columns": [
+            {
+              "expression": "shortened_dept",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.degree": {
+      "name": "degree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "division",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instructor": {
+      "name": "instructor",
+      "schema": "",
+      "columns": {
+        "ucinetid": {
+          "name": "ucinetid",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "instructor_search_index": {
+          "name": "instructor_search_index",
+          "columns": [
+            {
+              "expression": "(\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"ucinetid\", '')), 'A') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"name\", '')), 'B') ||\n SETWEIGHT(TO_TSVECTOR('english', COALESCE(\"title\", '')), 'B')\n)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instructor_to_websoc_instructor": {
+      "name": "instructor_to_websoc_instructor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instructor_ucinetid": {
+          "name": "instructor_ucinetid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "websoc_instructor_name": {
+          "name": "websoc_instructor_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "instructor_to_websoc_instructor_instructor_ucinetid_index": {
+          "name": "instructor_to_websoc_instructor_instructor_ucinetid_index",
+          "columns": [
+            {
+              "expression": "instructor_ucinetid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instructor_to_websoc_instructor_websoc_instructor_name_index": {
+          "name": "instructor_to_websoc_instructor_websoc_instructor_name_index",
+          "columns": [
+            {
+              "expression": "websoc_instructor_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instructor_to_websoc_instructor_instructor_ucinetid_websoc_instructor_name_index": {
+          "name": "instructor_to_websoc_instructor_instructor_ucinetid_websoc_instructor_name_index",
+          "columns": [
+            {
+              "expression": "instructor_ucinetid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "websoc_instructor_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instructor_to_websoc_instructor_instructor_ucinetid_instructor_ucinetid_fk": {
+          "name": "instructor_to_websoc_instructor_instructor_ucinetid_instructor_ucinetid_fk",
+          "tableFrom": "instructor_to_websoc_instructor",
+          "tableTo": "instructor",
+          "columnsFrom": ["instructor_ucinetid"],
+          "columnsTo": ["ucinetid"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instructor_to_websoc_instructor_websoc_instructor_name_websoc_instructor_name_fk": {
+          "name": "instructor_to_websoc_instructor_websoc_instructor_name_websoc_instructor_name_fk",
+          "tableFrom": "instructor_to_websoc_instructor",
+          "tableTo": "websoc_instructor",
+          "columnsFrom": ["websoc_instructor_name"],
+          "columnsTo": ["name"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.larc_section": {
+      "name": "larc_section",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_string": {
+          "name": "days_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_string": {
+          "name": "time_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructor": {
+          "name": "instructor",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "building": {
+          "name": "building",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meets_monday": {
+          "name": "meets_monday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "meets_tuesday": {
+          "name": "meets_tuesday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "meets_wednesday": {
+          "name": "meets_wednesday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "meets_thursday": {
+          "name": "meets_thursday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "meets_friday": {
+          "name": "meets_friday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "meets_saturday": {
+          "name": "meets_saturday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "meets_sunday": {
+          "name": "meets_sunday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "larc_section_course_id_index": {
+          "name": "larc_section_course_id_index",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "larc_section_course_id_websoc_course_id_fk": {
+          "name": "larc_section_course_id_websoc_course_id_fk",
+          "tableFrom": "larc_section",
+          "tableTo": "websoc_course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major": {
+      "name": "major",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "degree_id": {
+          "name": "degree_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "major_degree_id_index": {
+          "name": "major_degree_id_index",
+          "columns": [
+            {
+              "expression": "degree_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_degree_id_degree_id_fk": {
+          "name": "major_degree_id_degree_id_fk",
+          "tableFrom": "major",
+          "tableTo": "degree",
+          "columnsFrom": ["degree_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.minor": {
+      "name": "minor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prerequisite": {
+      "name": "prerequisite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dep_dept": {
+          "name": "dep_dept",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_id": {
+          "name": "prerequisite_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dependency_id": {
+          "name": "dependency_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "prerequisite_dep_dept_index": {
+          "name": "prerequisite_dep_dept_index",
+          "columns": [
+            {
+              "expression": "dep_dept",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prerequisite_prerequisite_id_index": {
+          "name": "prerequisite_prerequisite_id_index",
+          "columns": [
+            {
+              "expression": "prerequisite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prerequisite_dependency_id_index": {
+          "name": "prerequisite_dependency_id_index",
+          "columns": [
+            {
+              "expression": "dependency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prerequisite_prerequisite_id_dependency_id_index": {
+          "name": "prerequisite_prerequisite_id_dependency_id_index",
+          "columns": [
+            {
+              "expression": "prerequisite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dependency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.school_requirement": {
+      "name": "school_requirement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(2)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.specialization": {
+      "name": "specialization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "major_id": {
+          "name": "major_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "specialization_major_id_index": {
+          "name": "specialization_major_id_index",
+          "columns": [
+            {
+              "expression": "major_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "specialization_major_id_major_id_fk": {
+          "name": "specialization_major_id_major_id_fk",
+          "tableFrom": "specialization",
+          "tableTo": "major",
+          "columnsFrom": ["major_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.study_location": {
+      "name": "study_location",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.study_room": {
+      "name": "study_room",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "directions": {
+          "name": "directions",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tech_enhanced": {
+          "name": "tech_enhanced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_location_id": {
+          "name": "study_location_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "study_room_study_location_id_index": {
+          "name": "study_room_study_location_id_index",
+          "columns": [
+            {
+              "expression": "study_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "study_room_study_location_id_study_location_id_fk": {
+          "name": "study_room_study_location_id_study_location_id_fk",
+          "tableFrom": "study_room",
+          "tableTo": "study_location",
+          "columnsFrom": ["study_location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.study_room_slot": {
+      "name": "study_room_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "study_room_id": {
+          "name": "study_room_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start": {
+          "name": "start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end": {
+          "name": "end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_available": {
+          "name": "is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "study_room_slot_study_room_id_index": {
+          "name": "study_room_slot_study_room_id_index",
+          "columns": [
+            {
+              "expression": "study_room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "study_room_slot_study_room_id_start_end_index": {
+          "name": "study_room_slot_study_room_id_start_end_index",
+          "columns": [
+            {
+              "expression": "study_room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "study_room_slot_study_room_id_study_room_id_fk": {
+          "name": "study_room_slot_study_room_id_study_room_id_fk",
+          "tableFrom": "study_room_slot",
+          "tableTo": "study_room",
+          "columnsFrom": ["study_room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_course": {
+      "name": "websoc_course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "department_id": {
+          "name": "department_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "REPLACE(\"websoc_course\".\"dept_code\", ' ', '') || \"websoc_course\".\"course_number\"",
+            "type": "stored"
+          }
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "term",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_name": {
+          "name": "school_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dept_code": {
+          "name": "dept_code",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_title": {
+          "name": "course_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_number": {
+          "name": "course_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_numeric": {
+          "name": "course_numeric",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "CASE REGEXP_REPLACE(\"websoc_course\".\"course_number\", '\\D', '', 'g') WHEN '' THEN 0 ELSE REGEXP_REPLACE(\"websoc_course\".\"course_number\", '\\D', '', 'g')::INTEGER END",
+            "type": "stored"
+          }
+        },
+        "course_comment": {
+          "name": "course_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_link": {
+          "name": "prerequisite_link",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_1a": {
+          "name": "is_ge_1a",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_1b": {
+          "name": "is_ge_1b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_2": {
+          "name": "is_ge_2",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_3": {
+          "name": "is_ge_3",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_4": {
+          "name": "is_ge_4",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_5a": {
+          "name": "is_ge_5a",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_5b": {
+          "name": "is_ge_5b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_6": {
+          "name": "is_ge_6",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_7": {
+          "name": "is_ge_7",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ge_8": {
+          "name": "is_ge_8",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "websoc_course_department_id_index": {
+          "name": "websoc_course_department_id_index",
+          "columns": [
+            {
+              "expression": "department_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_course_id_index": {
+          "name": "websoc_course_course_id_index",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_school_name_dept_code_course_number_course_title_index": {
+          "name": "websoc_course_year_quarter_school_name_dept_code_course_number_course_title_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dept_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_1a_index": {
+          "name": "websoc_course_year_quarter_is_ge_1a_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_1a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_1b_index": {
+          "name": "websoc_course_year_quarter_is_ge_1b_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_1b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_2_index": {
+          "name": "websoc_course_year_quarter_is_ge_2_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_2",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_3_index": {
+          "name": "websoc_course_year_quarter_is_ge_3_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_3",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_4_index": {
+          "name": "websoc_course_year_quarter_is_ge_4_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_4",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_5a_index": {
+          "name": "websoc_course_year_quarter_is_ge_5a_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_5a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_5b_index": {
+          "name": "websoc_course_year_quarter_is_ge_5b_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_5b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_6_index": {
+          "name": "websoc_course_year_quarter_is_ge_6_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_6",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_7_index": {
+          "name": "websoc_course_year_quarter_is_ge_7_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_7",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_is_ge_8_index": {
+          "name": "websoc_course_year_quarter_is_ge_8_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ge_8",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_dept_code_index": {
+          "name": "websoc_course_year_quarter_dept_code_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dept_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_course_year_quarter_dept_code_course_number_index": {
+          "name": "websoc_course_year_quarter_dept_code_course_number_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dept_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_course_department_id_websoc_department_id_fk": {
+          "name": "websoc_course_department_id_websoc_department_id_fk",
+          "tableFrom": "websoc_course",
+          "tableTo": "websoc_department",
+          "columnsFrom": ["department_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_department": {
+      "name": "websoc_department",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "term",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dept_code": {
+          "name": "dept_code",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dept_name": {
+          "name": "dept_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dept_comment": {
+          "name": "dept_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_code_range_comments": {
+          "name": "section_code_range_comments",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_number_range_comments": {
+          "name": "course_number_range_comments",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "websoc_department_school_id_index": {
+          "name": "websoc_department_school_id_index",
+          "columns": [
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_department_year_quarter_school_id_dept_code_index": {
+          "name": "websoc_department_year_quarter_school_id_dept_code_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dept_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_department_school_id_websoc_school_id_fk": {
+          "name": "websoc_department_school_id_websoc_school_id_fk",
+          "tableFrom": "websoc_department",
+          "tableTo": "websoc_school",
+          "columnsFrom": ["school_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_instructor": {
+      "name": "websoc_instructor",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_location": {
+      "name": "websoc_location",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "building": {
+          "name": "building",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room": {
+          "name": "room",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "websoc_location_building_room_index": {
+          "name": "websoc_location_building_room_index",
+          "columns": [
+            {
+              "expression": "building",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_meta": {
+      "name": "websoc_meta",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_scraped": {
+          "name": "last_scraped",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_dept_scraped": {
+          "name": "last_dept_scraped",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_school": {
+      "name": "websoc_school",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "term",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_name": {
+          "name": "school_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_comment": {
+          "name": "school_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "websoc_school_year_quarter_school_name_index": {
+          "name": "websoc_school_year_quarter_school_name_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "school_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_section": {
+      "name": "websoc_section",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "term",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units": {
+          "name": "units",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "websoc_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructors": {
+          "name": "instructors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetings": {
+          "name": "meetings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_exam_string": {
+          "name": "final_exam_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_exam": {
+          "name": "final_exam",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_num": {
+          "name": "section_num",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_capacity": {
+          "name": "max_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_code": {
+          "name": "section_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_type": {
+          "name": "section_type",
+          "type": "websoc_section_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_requested": {
+          "name": "num_requested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restriction_string": {
+          "name": "restriction_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restriction_a": {
+          "name": "restriction_a",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_b": {
+          "name": "restriction_b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_c": {
+          "name": "restriction_c",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_d": {
+          "name": "restriction_d",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_e": {
+          "name": "restriction_e",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_f": {
+          "name": "restriction_f",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_g": {
+          "name": "restriction_g",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_h": {
+          "name": "restriction_h",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_i": {
+          "name": "restriction_i",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_j": {
+          "name": "restriction_j",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_k": {
+          "name": "restriction_k",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_l": {
+          "name": "restriction_l",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_m": {
+          "name": "restriction_m",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_n": {
+          "name": "restriction_n",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_o": {
+          "name": "restriction_o",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_r": {
+          "name": "restriction_r",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_s": {
+          "name": "restriction_s",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_x": {
+          "name": "restriction_x",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "num_on_waitlist": {
+          "name": "num_on_waitlist",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_waitlist_cap": {
+          "name": "num_waitlist_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_comment": {
+          "name": "section_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_new_only_reserved": {
+          "name": "num_new_only_reserved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_currently_total_enrolled": {
+          "name": "num_currently_total_enrolled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_currently_section_enrolled": {
+          "name": "num_currently_section_enrolled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_cancelled": {
+          "name": "is_cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "\"websoc_section\".\"section_comment\" LIKE '*** CANCELLED ***%'",
+            "type": "stored"
+          }
+        },
+        "web_url": {
+          "name": "web_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "websoc_section_course_id_index": {
+          "name": "websoc_section_course_id_index",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_section_year_quarter_section_code_index": {
+          "name": "websoc_section_year_quarter_section_code_index",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quarter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_section_course_id_websoc_course_id_fk": {
+          "name": "websoc_section_course_id_websoc_course_id_fk",
+          "tableFrom": "websoc_section",
+          "tableTo": "websoc_course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_section_enrollment": {
+      "name": "websoc_section_enrollment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "year": {
+          "name": "year",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarter": {
+          "name": "quarter",
+          "type": "term",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_capacity": {
+          "name": "max_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_currently_total_enrolled": {
+          "name": "num_currently_total_enrolled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_on_waitlist": {
+          "name": "num_on_waitlist",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_waitlist_cap": {
+          "name": "num_waitlist_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_requested": {
+          "name": "num_requested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_new_only_reserved": {
+          "name": "num_new_only_reserved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "websoc_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "websoc_section_enrollment_section_id_index": {
+          "name": "websoc_section_enrollment_section_id_index",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_section_enrollment_section_id_created_at_index": {
+          "name": "websoc_section_enrollment_section_id_created_at_index",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_section_enrollment_section_id_websoc_section_id_fk": {
+          "name": "websoc_section_enrollment_section_id_websoc_section_id_fk",
+          "tableFrom": "websoc_section_enrollment",
+          "tableTo": "websoc_section",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_section_grade": {
+      "name": "websoc_section_grade",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_a_count": {
+          "name": "grade_a_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_b_count": {
+          "name": "grade_b_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_c_count": {
+          "name": "grade_c_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_d_count": {
+          "name": "grade_d_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_f_count": {
+          "name": "grade_f_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_p_count": {
+          "name": "grade_p_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_np_count": {
+          "name": "grade_np_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_w_count": {
+          "name": "grade_w_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_gpa": {
+          "name": "average_gpa",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "websoc_section_grade_section_id_index": {
+          "name": "websoc_section_grade_section_id_index",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_section_grade_section_id_websoc_section_id_fk": {
+          "name": "websoc_section_grade_section_id_websoc_section_id_fk",
+          "tableFrom": "websoc_section_grade",
+          "tableTo": "websoc_section",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "websoc_section_grade_section_id_unique": {
+          "name": "websoc_section_grade_section_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["section_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_section_meeting": {
+      "name": "websoc_section_meeting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_code": {
+          "name": "section_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_index": {
+          "name": "meeting_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_string": {
+          "name": "time_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_is_tba": {
+          "name": "time_is_tba",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "\"websoc_section_meeting\".\"time_string\" LIKE '%TBA%'",
+            "type": "stored"
+          }
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_string": {
+          "name": "days_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meets_monday": {
+          "name": "meets_monday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "meets_tuesday": {
+          "name": "meets_tuesday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "meets_wednesday": {
+          "name": "meets_wednesday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "meets_thursday": {
+          "name": "meets_thursday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "meets_friday": {
+          "name": "meets_friday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "meets_saturday": {
+          "name": "meets_saturday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "meets_sunday": {
+          "name": "meets_sunday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "websoc_section_meeting_section_id_index": {
+          "name": "websoc_section_meeting_section_id_index",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_section_meeting_section_id_websoc_section_id_fk": {
+          "name": "websoc_section_meeting_section_id_websoc_section_id_fk",
+          "tableFrom": "websoc_section_meeting",
+          "tableTo": "websoc_section",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_section_meeting_to_location": {
+      "name": "websoc_section_meeting_to_location",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "websoc_section_meeting_to_location_section_id_index": {
+          "name": "websoc_section_meeting_to_location_section_id_index",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_section_meeting_to_location_location_id_index": {
+          "name": "websoc_section_meeting_to_location_location_id_index",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_section_meeting_to_location_section_id_location_id_index": {
+          "name": "websoc_section_meeting_to_location_section_id_location_id_index",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_section_meeting_to_location_section_id_websoc_section_meeting_id_fk": {
+          "name": "websoc_section_meeting_to_location_section_id_websoc_section_meeting_id_fk",
+          "tableFrom": "websoc_section_meeting_to_location",
+          "tableTo": "websoc_section_meeting",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "websoc_section_meeting_to_location_location_id_websoc_location_id_fk": {
+          "name": "websoc_section_meeting_to_location_location_id_websoc_location_id_fk",
+          "tableFrom": "websoc_section_meeting_to_location",
+          "tableTo": "websoc_location",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.websoc_section_to_instructor": {
+      "name": "websoc_section_to_instructor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructor_name": {
+          "name": "instructor_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "websoc_section_to_instructor_section_id_index": {
+          "name": "websoc_section_to_instructor_section_id_index",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "websoc_section_to_instructor_instructor_name_index": {
+          "name": "websoc_section_to_instructor_instructor_name_index",
+          "columns": [
+            {
+              "expression": "instructor_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "websoc_section_to_instructor_section_id_websoc_section_id_fk": {
+          "name": "websoc_section_to_instructor_section_id_websoc_section_id_fk",
+          "tableFrom": "websoc_section_to_instructor",
+          "tableTo": "websoc_section",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "websoc_section_to_instructor_instructor_name_websoc_instructor_name_fk": {
+          "name": "websoc_section_to_instructor_instructor_name_websoc_instructor_name_fk",
+          "tableFrom": "websoc_section_to_instructor",
+          "tableTo": "websoc_instructor",
+          "columnsFrom": ["instructor_name"],
+          "columnsTo": ["name"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.course_level": {
+      "name": "course_level",
+      "schema": "public",
+      "values": ["LowerDiv", "UpperDiv", "Graduate"]
+    },
+    "public.division": {
+      "name": "division",
+      "schema": "public",
+      "values": ["Undergraduate", "Graduate"]
+    },
+    "public.term": {
+      "name": "term",
+      "schema": "public",
+      "values": ["Fall", "Winter", "Spring", "Summer1", "Summer10wk", "Summer2"]
+    },
+    "public.websoc_section_type": {
+      "name": "websoc_section_type",
+      "schema": "public",
+      "values": [
+        "Act",
+        "Col",
+        "Dis",
+        "Fld",
+        "Lab",
+        "Lec",
+        "Qiz",
+        "Res",
+        "Sem",
+        "Stu",
+        "Tap",
+        "Tut"
+      ]
+    },
+    "public.websoc_status": {
+      "name": "websoc_status",
+      "schema": "public",
+      "values": ["OPEN", "Waitl", "FULL", "NewOnly"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.course_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shortened_dept": {
+          "name": "shortened_dept",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "REPLACE(\"course\".\"department\", ' ', '')",
+            "type": "stored"
+          }
+        },
+        "department_alias": {
+          "name": "department_alias",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_number": {
+          "name": "course_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_numeric": {
+          "name": "course_numeric",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "CASE REGEXP_REPLACE(\"course\".\"course_number\", '\\D', '', 'g') WHEN '' THEN 0 ELSE REGEXP_REPLACE(\"course\".\"course_number\", '\\D', '', 'g')::INTEGER END",
+            "type": "stored"
+          }
+        },
+        "school": {
+          "name": "school",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_level": {
+          "name": "course_level",
+          "type": "course_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_units": {
+          "name": "min_units",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_units": {
+          "name": "max_units",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department_name": {
+          "name": "department_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_tree": {
+          "name": "prerequisite_tree",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisite_text": {
+          "name": "prerequisite_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repeatability": {
+          "name": "repeatability",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grading_option": {
+          "name": "grading_option",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "concurrent": {
+          "name": "concurrent",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "same_as": {
+          "name": "same_as",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restriction": {
+          "name": "restriction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overlap": {
+          "name": "overlap",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corequisites": {
+          "name": "corequisites",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_1a": {
+          "name": "is_ge_1a",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_1b": {
+          "name": "is_ge_1b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_2": {
+          "name": "is_ge_2",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_3": {
+          "name": "is_ge_3",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_4": {
+          "name": "is_ge_4",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_5a": {
+          "name": "is_ge_5a",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_5b": {
+          "name": "is_ge_5b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_6": {
+          "name": "is_ge_6",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_7": {
+          "name": "is_ge_7",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ge_8": {
+          "name": "is_ge_8",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ge_text": {
+          "name": "ge_text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "select \"course\".\"id\", \"course\".\"updated_at\", \"course\".\"department\", \"course\".\"shortened_dept\", \"course\".\"department_alias\", \"course\".\"course_number\", \"course\".\"course_numeric\", \"course\".\"school\", \"course\".\"title\", \"course\".\"course_level\", \"course\".\"min_units\", \"course\".\"max_units\", \"course\".\"description\", \"course\".\"department_name\", \"course\".\"prerequisite_tree\", \"course\".\"prerequisite_text\", \"course\".\"repeatability\", \"course\".\"grading_option\", \"course\".\"concurrent\", \"course\".\"same_as\", \"course\".\"restriction\", \"course\".\"overlap\", \"course\".\"corequisites\", \"course\".\"is_ge_1a\", \"course\".\"is_ge_1b\", \"course\".\"is_ge_2\", \"course\".\"is_ge_3\", \"course\".\"is_ge_4\", \"course\".\"is_ge_5a\", \"course\".\"is_ge_5b\", \"course\".\"is_ge_6\", \"course\".\"is_ge_7\", \"course\".\"is_ge_8\", \"course\".\"ge_text\", \n        ARRAY_REMOVE(COALESCE(\n          (\n            SELECT ARRAY_AGG(\n              CASE WHEN \"prerequisite_course\".\"id\" IS NULL THEN NULL\n              ELSE JSONB_BUILD_OBJECT(\n              'id', \"prerequisite_course\".\"id\",\n              'title', \"prerequisite_course\".\"title\",\n              'department', \"prerequisite_course\".\"department\",\n              'courseNumber', \"prerequisite_course\".\"course_number\"\n              )\n              END\n            )\n            FROM \"prerequisite\"\n            LEFT JOIN \"course\" \"prerequisite_course\" ON \"prerequisite_course\".\"id\" = \"prerequisite\".\"prerequisite_id\"\n            WHERE \"prerequisite\".\"dependency_id\" = \"course\".\"id\"\n          ),\n        ARRAY[]::JSONB[]), NULL)\n         as \"prerequisites\", \n        ARRAY_REMOVE(COALESCE(\n          (\n            SELECT ARRAY_AGG(\n              CASE WHEN \"dependency_course\".\"id\" IS NULL THEN NULL\n              ELSE JSONB_BUILD_OBJECT(\n                'id', \"dependency_course\".\"id\",\n                'title', \"dependency_course\".\"title\",\n                'department', \"dependency_course\".\"department\",\n                'courseNumber', \"dependency_course\".\"course_number\"\n              )\n              END\n            )\n            FROM \"prerequisite\" \"dependency\"\n            LEFT JOIN \"course\" \"dependency_course\" ON \"dependency_course\".\"id\" = \"dependency\".\"dependency_id\"\n            WHERE \"dependency\".\"prerequisite_id\" = \"course\".\"id\"\n          ),\n        ARRAY[]::JSONB[]), NULL)\n         as \"dependencies\", \n          ARRAY_REMOVE(ARRAY_AGG(DISTINCT\n            CASE WHEN \"websoc_course\".\"year\" IS NULL THEN NULL\n            ELSE CONCAT(\"websoc_course\".\"year\", ' ', \"websoc_course\".\"quarter\")\n            END\n          ), NULL)\n           as \"terms\", \n        ARRAY_REMOVE(COALESCE(ARRAY_AGG(DISTINCT\n          CASE WHEN \"instructor\".\"ucinetid\" IS NULL THEN NULL\n          ELSE JSONB_BUILD_OBJECT(\n            'ucinetid', \"instructor\".\"ucinetid\",\n            'name', \"instructor\".\"name\",\n            'title', \"instructor\".\"title\",\n            'email', \"instructor\".\"email\",\n            'department', \"instructor\".\"department\",\n            'shortenedNames', ARRAY(\n              SELECT \"instructor_to_websoc_instructor\".\"websoc_instructor_name\"\n              FROM \"instructor_to_websoc_instructor\"\n              WHERE \"instructor_to_websoc_instructor\".\"instructor_ucinetid\" = \"instructor\".\"ucinetid\"\n            )\n          )\n          END\n        ), ARRAY[]::JSONB[]), NULL)\n         as \"instructors\" from \"course\" left join \"websoc_course\" on \"websoc_course\".\"course_id\" = \"course\".\"id\" left join \"websoc_section\" on \"websoc_section\".\"course_id\" = \"websoc_course\".\"id\" left join \"websoc_section_to_instructor\" on \"websoc_section_to_instructor\".\"section_id\" = \"websoc_section\".\"id\" left join \"websoc_instructor\" on \"websoc_instructor\".\"name\" = \"websoc_section_to_instructor\".\"instructor_name\" left join \"instructor_to_websoc_instructor\" on \"instructor_to_websoc_instructor\".\"websoc_instructor_name\" = \"websoc_instructor\".\"name\" left join \"instructor\" on (\"instructor\".\"ucinetid\" = \"instructor_to_websoc_instructor\".\"instructor_ucinetid\" and \"instructor\".\"ucinetid\" is not null and \"instructor\".\"ucinetid\" <> 'student') group by \"course\".\"id\"",
+      "name": "course_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": true
+    },
+    "public.instructor_view": {
+      "columns": {
+        "ucinetid": {
+          "name": "ucinetid",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "with \"shortened_names_cte\" as (select \"instructor_ucinetid\", ARRAY_AGG(\"websoc_instructor_name\") as \"shortened_names\" from \"instructor_to_websoc_instructor\" group by \"instructor_to_websoc_instructor\".\"instructor_ucinetid\"), \"courses_cte\" as (with \"terms_cte\" as (select \"course\".\"id\", \"instructor_to_websoc_instructor\".\"instructor_ucinetid\", \n          ARRAY_REMOVE(ARRAY_AGG(DISTINCT\n            CASE WHEN \"websoc_course\".\"year\" IS NULL THEN NULL\n            ELSE CONCAT(\"websoc_course\".\"year\", ' ', \"websoc_course\".\"quarter\")\n            END\n          ), NULL) as \"terms\" from \"course\" left join \"websoc_course\" on \"websoc_course\".\"course_id\" = \"course\".\"id\" left join \"websoc_section\" on \"websoc_section\".\"course_id\" = \"websoc_course\".\"id\" left join \"websoc_section_to_instructor\" on \"websoc_section_to_instructor\".\"section_id\" = \"websoc_section\".\"id\" left join \"websoc_instructor\" on \"websoc_instructor\".\"name\" = \"websoc_section_to_instructor\".\"instructor_name\" left join \"instructor_to_websoc_instructor\" on \"instructor_to_websoc_instructor\".\"websoc_instructor_name\" = \"websoc_instructor\".\"name\" group by \"course\".\"id\", \"instructor_to_websoc_instructor\".\"instructor_ucinetid\") select \"terms_cte\".\"instructor_ucinetid\", \"course\".\"id\", \n          CASE WHEN \"course\".\"id\" IS NULL\n          THEN NULL\n          ELSE JSONB_BUILD_OBJECT(\n               'id', \"course\".\"id\",\n               'title', \"course\".\"title\",\n               'department', \"course\".\"department\",\n               'courseNumber', \"course\".\"course_number\",\n               'terms', COALESCE(\"terms\", ARRAY[]::TEXT[])\n          )\n          END\n           as \"course_info\" from \"course\" left join \"terms_cte\" on \"terms_cte\".\"id\" = \"course\".\"id\" group by \"course\".\"id\", \"terms_cte\".\"instructor_ucinetid\", \"terms\") select \"instructor\".\"ucinetid\", \"instructor\".\"name\", \"instructor\".\"title\", \"instructor\".\"email\", \"instructor\".\"department\", COALESCE(\"shortened_names\", ARRAY[]::TEXT[]) as \"shortened_names\", \n          ARRAY_REMOVE(ARRAY_AGG(DISTINCT \"course_info\"), NULL)\n         as \"courses\" from \"instructor\" left join \"shortened_names_cte\" on \"shortened_names_cte\".\"instructor_ucinetid\" = \"instructor\".\"ucinetid\" left join \"courses_cte\" on \"courses_cte\".\"instructor_ucinetid\" = \"instructor\".\"ucinetid\" where \"instructor\".\"ucinetid\" <> 'student' group by \"instructor\".\"ucinetid\", \"shortened_names\"",
+      "name": "instructor_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": true
+    },
+    "public.study_room_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "directions": {
+          "name": "directions",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tech_enhanced": {
+          "name": "tech_enhanced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "select \"study_room\".\"id\", \"study_room\".\"name\", \"study_room\".\"capacity\", \"study_room\".\"location\", \"study_room\".\"description\", \"study_room\".\"directions\", \"study_room\".\"tech_enhanced\", ARRAY_AGG(JSONB_BUILD_OBJECT(\n      'studyRoomId', \"study_room_slot\".\"study_room_id\",\n      'start', to_json(\"study_room_slot\".\"start\" AT TIME ZONE 'America/Los_Angeles'),\n      'end', to_json(\"study_room_slot\".\"end\" AT TIME ZONE 'America/Los_Angeles'),\n      'isAvailable', \"study_room_slot\".\"is_available\"\n    )) as \"slots\" from \"study_room\" left join \"study_room_slot\" on \"study_room\".\"id\" = \"study_room_slot\".\"study_room_id\" group by \"study_room\".\"id\"",
+      "name": "study_room_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": true
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1738124981227,
       "tag": "0009_uc_ge_requirements",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1739651540396,
+      "tag": "0010_shortened_dept",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -486,6 +486,9 @@ export const course = pgTable(
     id: varchar("id").primaryKey(),
     updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true }).notNull(),
     department: varchar("department").notNull(),
+    shortenedDept: varchar("shortened_dept")
+      .notNull()
+      .generatedAlwaysAs((): SQL => sql`REPLACE(${course.department}, ' ', '')`),
     departmentAlias: varchar("department_alias"),
     courseNumber: varchar("course_number").notNull(),
     courseNumeric: integer("course_numeric")
@@ -535,6 +538,7 @@ export const course = pgTable(
  SETWEIGHT(TO_TSVECTOR('english', COALESCE(${table.description}, '')), 'D')
 )`,
     ),
+    index("shortened_dept").on(table.shortenedDept),
   ],
 );
 


### PR DESCRIPTION
## Description

This PR aims to address two key issues with our handling of wildcards.

### Department-wide wildcards

For reasons that were never documented, wildcards for an entire department with no other qualifier (e.g. BIOSCI @) were never properly handled. This PR implements handling for such cases by dumping all courses in the department. This is a substantial amount of data, but no feasible workaround exists as department-wide wildcards may cohabitate with other complex requirements.

While implementing this feature, I noted that the department code given by DegreeWorks is the shortened version (without whitespace). A generated column and index thereon is added so that this data is readily and correctly accessible by the scraper.

### Wildcard translation to RegExp

We also aim to correct our previous incorrect assumption of what the wildcard `@` translates to. After some investigation, we present and implement the following new assumption.

We define a **wildcard block** as one or more consecutive (i.e. not broken by whitespace) occurrences of `@`. A wildcard block that has _n_ occurrences of `@` translates to the regular expression `\w{n,}`. It is worth noting of course that `\w{1,}` collapses to `\w+`, which is similar to the theory posited in #120.

So far, we have only observed occurrences of wildcard blocks with _n_ `\in` [1, 2], so the implementation reflects this fact. We argue that the pathological cases of _n_ > 2 are unlikely to occur in practice as there are no four-digit course numbers, and upper division courses with significant prefix/suffix use in their numbers are almost always covered by the _n_ = 2 case.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #120; closes #123.

## Motivation and Context

fixes PP (allegedly)

## How Has This Been Tested?
Instrumented with logging locally. Degreeworks data in production is in the process of being refreshed.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
