### PR TITLE
fix: typo on AP calc BC

### DIFF
--- a/apps/data-pipeline/ap-exams-importer/src/data.ts
+++ b/apps/data-pipeline/ap-exams-importer/src/data.ts
@@ -541,7 +541,7 @@ export default {
         unitsGranted: 8,
         electiveUnitsGranted: 0,
         geGranted: [],
-        coursesGranted: { OR: [{ AND: ["MATH 2A, MATH 2B"] }, { AND: ["MATH 5A", "MATH 5B"] }] },
+        coursesGranted: { OR: [{ AND: ["MATH 2A", "MATH 2B"] }, { AND: ["MATH 5A", "MATH 5B"] }] },
       },
     ],
   },


### PR DESCRIPTION
## Description

Fix a typo in the course credit granted for AP Calculus BC.
Introduced in #129.

## Related Issue

#144

# Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
