### PR TITLE
fix(degreeworks-scraper): fix getMapping url

### DIFF
--- a/apps/data-pipeline/degreeworks-scraper/src/components/DegreeworksClient.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/DegreeworksClient.ts
@@ -160,7 +160,9 @@ export class DegreeworksClient {
   }
 
   async getMapping<T extends string>(path: T): Promise<Map<string, string>> {
-    const res = await fetch(`${DegreeworksClient.API_URL}/${path}`, { headers: this.headers });
+    const res = await fetch(`${DegreeworksClient.API_URL}/validations/special-entities/${path}`, {
+      headers: this.headers,
+    });
     await this.sleep();
     const json: DWMappingResponse<T> = await res.json();
     return new Map(json._embedded[path].map((x) => [x.key, x.description]));


### PR DESCRIPTION
Fix #180.

Correct URL determined by Network tab of inspect element.
Scraper is known to be working now.

No need to re-run scraper or update any data at this time.

No schema or docs change.
