### PR TITLE
fix: unified search results of different types can't clobber each other

### DIFF
--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -183,8 +183,11 @@ export class SearchService {
         },
       ),
     );
-    const courses = await this.courseMappingFromResults(results.course);
-    const instructors = await this.instructorMappingFromResults(results.instructor);
+
+    const lookedUp = {
+      course: await this.courseMappingFromResults(results.course),
+      instructor: await this.instructorMappingFromResults(results.instructor),
+    };
 
     return {
       count: results.course.size + results.instructor.size,
@@ -192,13 +195,13 @@ export class SearchService {
         ...results.course.entries().map(([key, rank]) => ({
           key,
           type: "course" as const,
-          result: getFromMapOrThrow(courses, key),
+          result: getFromMapOrThrow(lookedUp.course, key),
           rank,
         })),
         ...results.instructor.entries().map(([key, rank]) => ({
           key,
           type: "instructor" as const,
-          result: getFromMapOrThrow(instructors, key),
+          result: getFromMapOrThrow(lookedUp.instructor, key),
           rank,
         })),
       ]

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -51,6 +51,7 @@ function toQuery(query: string) {
 }
 
 type SearchServiceInput = z.infer<typeof searchQuerySchema>;
+type SearchResultType = "course" | "instructor";
 
 export class SearchService {
   constructor(
@@ -156,6 +157,7 @@ export class SearchService {
     const results = await unionAll(
       this.db
         .select({
+          type: sql<SearchResultType>`'course'`,
           id: course.id,
           rank: sql`TS_RANK(${COURSES_WEIGHTS}, ${query})`.mapWith(Number),
         })
@@ -163,36 +165,43 @@ export class SearchService {
         .where(sql`${COURSES_WEIGHTS} @@ ${query}`),
       this.db
         .select({
+          type: sql<SearchResultType>`'instructor'`,
           id: instructor.ucinetid,
           rank: sql`TS_RANK(${INSTRUCTORS_WEIGHTS}, ${query})`.mapWith(Number),
         })
         .from(instructor)
         .where(sql`${INSTRUCTORS_WEIGHTS} @@ ${query}`),
     ).then((rows) =>
-      rows.reduce((acc, row) => acc.set(row.id, row.rank), new Map<string, number>()),
+      rows.reduce(
+        (acc, row) => {
+          acc[row.type].set(row.id, row.rank);
+          return acc;
+        },
+        {
+          course: new Map<string, number>(),
+          instructor: new Map<string, number>(),
+        },
+      ),
     );
-    const courses = await this.courseMappingFromResults(results);
-    const instructors = await this.instructorMappingFromResults(results);
+    const courses = await this.courseMappingFromResults(results.course);
+    const instructors = await this.instructorMappingFromResults(results.instructor);
+
     return {
-      count: results.size,
-      results: results
-        .entries()
-        .map(([key, rank]) =>
-          courses.has(key)
-            ? {
-                key,
-                type: "course" as const,
-                result: getFromMapOrThrow(courses, key),
-                rank,
-              }
-            : {
-                key,
-                type: "instructor" as const,
-                result: getFromMapOrThrow(instructors, key),
-                rank,
-              },
-        )
-        .toArray()
+      count: results.course.size + results.instructor.size,
+      results: [
+        ...results.course.entries().map(([key, rank]) => ({
+          key,
+          type: "course" as const,
+          result: getFromMapOrThrow(courses, key),
+          rank,
+        })),
+        ...results.instructor.entries().map(([key, rank]) => ({
+          key,
+          type: "instructor" as const,
+          result: getFromMapOrThrow(instructors, key),
+          rank,
+        })),
+      ]
         .toSorted((a, b) => {
           const rankDiff = b.rank - a.rank;
           return Math.abs(rankDiff) < Number.EPSILON


### PR DESCRIPTION
## Description

By asking the database to return the type of a search result, we can discern which table the result came from (courses or instructors).
We then use this to look the ID up in the correct table.
Since we are now using two distinct maps keyed by ID (one for course IDs, one for instructor IDs), it is now possible to return two entities of different types with identical ID.

This also has the side effect of reducing failed ID lookups since we never look up an instructor ID as a course or vice versa.

## Related Issue

By the third statement above, we fix issue #188.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
