### PR TITLE
Search filters

### DIFF
--- a/apps/api/src/graphql/schema/search.ts
+++ b/apps/api/src/graphql/schema/search.ts
@@ -6,6 +6,11 @@ type SearchResult @cacheControl(maxAge: 86400) {
     rank: Float!
 }
 
+enum SearchResultType {
+    course,
+    instructor,
+}
+
 type SearchResponse {
     count: Int!
     results: [SearchResult!]!
@@ -15,6 +20,7 @@ input SearchQuery {
     query: String!
     take: Int
     skip: Int
+    resultType: SearchResultType
 }
 
 extend type Query {

--- a/apps/api/src/graphql/schema/search.ts
+++ b/apps/api/src/graphql/schema/search.ts
@@ -21,6 +21,11 @@ input SearchQuery {
     take: Int
     skip: Int
     resultType: SearchResultType
+    department: String
+    courseLevel: CourseLevel
+    minUnits: Float
+    maxUnits: Float
+    ge: String
 }
 
 extend type Query {

--- a/apps/api/src/schema/courses.ts
+++ b/apps/api/src/schema/courses.ts
@@ -2,9 +2,13 @@ import { z } from "@hono/zod-openapi";
 import type { PrerequisiteTree } from "@packages/db/schema";
 import { instructorPreviewSchema } from "./instructors";
 
-const inputCourseLevels = ["LowerDiv", "UpperDiv", "Graduate"] as const;
+export const inputCourseLevels = ["LowerDiv", "UpperDiv", "Graduate"] as const;
 
-const inputGECategories = [
+export const inputCourseLevelSchema = z.enum(inputCourseLevels, {
+  message: "If provided, 'courseLevel' must be 'LowerDiv', 'UpperDiv', or 'Graduate'",
+});
+
+export const inputGECategories = [
   "GE-1A",
   "GE-1B",
   "GE-2",
@@ -54,11 +58,7 @@ export const coursesQuerySchema = z.object({
   courseNumber: z.string().optional(),
   courseNumeric: z.coerce.number().optional(),
   titleContains: z.string().optional(),
-  courseLevel: z
-    .enum(inputCourseLevels, {
-      message: "If provided, 'courseLevel' must be 'LowerDiv', 'UpperDiv', or 'Graduate'",
-    })
-    .optional(),
+  courseLevel: inputCourseLevelSchema.optional(),
   minUnits: z.coerce.number().optional(),
   maxUnits: z.coerce.number().optional(),
   descriptionContains: z.string().optional(),

--- a/apps/api/src/schema/search.ts
+++ b/apps/api/src/schema/search.ts
@@ -1,5 +1,5 @@
 import { z } from "@hono/zod-openapi";
-import { courseSchema } from "./courses.ts";
+import { courseSchema, inputCourseLevelSchema, inputGECategories } from "./courses.ts";
 import { instructorSchema } from "./instructors.ts";
 
 export const searchQuerySchema = z.object({
@@ -7,6 +7,22 @@ export const searchQuerySchema = z.object({
   take: z.coerce.number().lte(100, "Page size must be less than or equal to 100").default(100),
   skip: z.coerce.number().default(0),
   resultType: z.union([z.literal("course"), z.literal("instructor")]).optional(),
+  department: z.string().optional().openapi({
+    description: "If searching for courses, they must be from this department",
+    example: "BIO SCI",
+  }),
+  courseLevel: inputCourseLevelSchema.optional().openapi({
+    description: "If searching for courses, they must be at this level",
+  }),
+  minUnits: z.coerce.number().optional().openapi({
+    description: "If searching for courses, they must grant at least this many units upon passage",
+  }),
+  maxUnits: z.coerce.number().optional().openapi({
+    description: "If searching for courses, they must grant at most this many units upon passage",
+  }),
+  ge: z.enum(inputGECategories).optional().openapi({
+    description: "If searching for courses, they must fulfill this GE category",
+  }),
 });
 
 export const searchResultSchema = z.discriminatedUnion("type", [

--- a/apps/api/src/services/courses.ts
+++ b/apps/api/src/services/courses.ts
@@ -9,12 +9,13 @@ import type {
 import { outputGECategories } from "$schema";
 import type { database } from "@packages/db";
 import type { SQL } from "@packages/db/drizzle";
-import { and, eq, gte, ilike, inArray, lt, lte } from "@packages/db/drizzle";
+import { and, eq, gte, ilike, inArray, lt } from "@packages/db/drizzle";
 import type { CourseLevel, course } from "@packages/db/schema";
 import { courseView } from "@packages/db/schema";
 import { isTrue } from "@packages/db/utils";
 import { orNull } from "@packages/stdlib";
 import type { z } from "zod";
+import { buildUnitBoundsQuery } from "./util.ts";
 
 type CoursesServiceInput = z.infer<typeof coursesQuerySchema>;
 
@@ -97,12 +98,7 @@ function buildQuery(input: CoursesServiceInput | CoursesByCursorServiceInput) {
         break;
     }
   }
-  if (input.minUnits) {
-    conditions.push(gte(courseView.minUnits, input.minUnits.toString(10)));
-  }
-  if (input.maxUnits) {
-    conditions.push(lte(courseView.maxUnits, input.maxUnits.toString(10)));
-  }
+  conditions.push(...buildUnitBoundsQuery(courseView, input.minUnits, input.maxUnits));
   if (input.descriptionContains) {
     conditions.push(ilike(courseView.description, `%${input.descriptionContains}%`));
   }

--- a/apps/api/src/services/grades.ts
+++ b/apps/api/src/services/grades.ts
@@ -33,8 +33,8 @@ function buildQuery(input: GradesServiceInput) {
   if (input.sectionCode) {
     conditions.push(eq(websocSection.sectionCode, Number.parseInt(input.sectionCode)));
   }
-  conditions.push(...buildDivisionQuery(input));
-  conditions.push(...buildGEQuery(input));
+  conditions.push(...buildDivisionQuery(input.division));
+  conditions.push(...buildGEQuery(input.ge));
   if (input.excludePNP) {
     conditions.push(
       or(

--- a/apps/api/src/services/larc.ts
+++ b/apps/api/src/services/larc.ts
@@ -20,14 +20,14 @@ function buildQuery(input: LarcSessionServiceInput) {
   if (input.department) {
     conditions.push(eq(websocCourse.deptCode, input.department));
   }
-  conditions.push(...buildMultiCourseNumberQuery(input));
+  conditions.push(...buildMultiCourseNumberQuery(input.courseNumber));
   if (input.instructorName) {
     conditions.push(ilike(larcSection.instructor, `${input.instructorName}%`));
   }
   if (input.building) {
     conditions.push(eq(larcSection.building, input.building.toUpperCase()));
   }
-  conditions.push(...buildDaysOfWeekQuery(larcSection, input));
+  conditions.push(...buildDaysOfWeekQuery(larcSection, input.days));
   if (input.startTime) {
     conditions.push(gte(larcSection.startTime, input.startTime));
   }

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -183,8 +183,11 @@ export class SearchService {
         },
       ),
     );
-    const courses = await this.courseMappingFromResults(results.course);
-    const instructors = await this.instructorMappingFromResults(results.instructor);
+
+    const lookedUp = {
+      course: await this.courseMappingFromResults(results.course),
+      instructor: await this.instructorMappingFromResults(results.instructor),
+    };
 
     return {
       count: results.course.size + results.instructor.size,
@@ -192,13 +195,13 @@ export class SearchService {
         ...results.course.entries().map(([key, rank]) => ({
           key,
           type: "course" as const,
-          result: getFromMapOrThrow(courses, key),
+          result: getFromMapOrThrow(lookedUp.course, key),
           rank,
         })),
         ...results.instructor.entries().map(([key, rank]) => ({
           key,
           type: "instructor" as const,
-          result: getFromMapOrThrow(instructors, key),
+          result: getFromMapOrThrow(lookedUp.instructor, key),
           rank,
         })),
       ]

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -51,6 +51,7 @@ function toQuery(query: string) {
 }
 
 type SearchServiceInput = z.infer<typeof searchQuerySchema>;
+type SearchResultType = "course" | "instructor";
 
 export class SearchService {
   constructor(
@@ -156,6 +157,7 @@ export class SearchService {
     const results = await unionAll(
       this.db
         .select({
+          type: sql<SearchResultType>`'course'`,
           id: course.id,
           rank: sql`TS_RANK(${COURSES_WEIGHTS}, ${query})`.mapWith(Number),
         })
@@ -163,36 +165,43 @@ export class SearchService {
         .where(sql`${COURSES_WEIGHTS} @@ ${query}`),
       this.db
         .select({
+          type: sql<SearchResultType>`'instructor'`,
           id: instructor.ucinetid,
           rank: sql`TS_RANK(${INSTRUCTORS_WEIGHTS}, ${query})`.mapWith(Number),
         })
         .from(instructor)
         .where(sql`${INSTRUCTORS_WEIGHTS} @@ ${query}`),
     ).then((rows) =>
-      rows.reduce((acc, row) => acc.set(row.id, row.rank), new Map<string, number>()),
+      rows.reduce(
+        (acc, row) => {
+          acc[row.type].set(row.id, row.rank);
+          return acc;
+        },
+        {
+          course: new Map<string, number>(),
+          instructor: new Map<string, number>(),
+        },
+      ),
     );
-    const courses = await this.courseMappingFromResults(results);
-    const instructors = await this.instructorMappingFromResults(results);
+    const courses = await this.courseMappingFromResults(results.course);
+    const instructors = await this.instructorMappingFromResults(results.instructor);
+
     return {
-      count: results.size,
-      results: results
-        .entries()
-        .map(([key, rank]) =>
-          courses.has(key)
-            ? {
-                key,
-                type: "course" as const,
-                result: getFromMapOrThrow(courses, key),
-                rank,
-              }
-            : {
-                key,
-                type: "instructor" as const,
-                result: getFromMapOrThrow(instructors, key),
-                rank,
-              },
-        )
-        .toArray()
+      count: results.course.size + results.instructor.size,
+      results: [
+        ...results.course.entries().map(([key, rank]) => ({
+          key,
+          type: "course" as const,
+          result: getFromMapOrThrow(courses, key),
+          rank,
+        })),
+        ...results.instructor.entries().map(([key, rank]) => ({
+          key,
+          type: "instructor" as const,
+          result: getFromMapOrThrow(instructors, key),
+          rank,
+        })),
+      ]
         .toSorted((a, b) => {
           const rankDiff = b.rank - a.rank;
           return Math.abs(rankDiff) < Number.EPSILON

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -6,12 +6,13 @@ import type {
 } from "$schema";
 import type { z } from "@hono/zod-openapi";
 import type { database } from "@packages/db";
-import { asc, desc, sql } from "@packages/db/drizzle";
+import { and, asc, desc, eq, sql } from "@packages/db/drizzle";
 import { unionAll } from "@packages/db/drizzle-pg";
 import { course, instructor } from "@packages/db/schema";
 import { getFromMapOrThrow } from "@packages/stdlib";
 import type { CoursesService } from "./courses";
 import type { InstructorsService } from "./instructors";
+import { buildDivisionQuery, buildGEQuery, buildUnitBoundsQuery } from "./util.ts";
 
 const COURSES_WEIGHTS = sql`(
   SETWEIGHT(TO_TSVECTOR('english', COALESCE(${course.id}, '')), 'A') ||
@@ -60,6 +61,20 @@ export class SearchService {
     private readonly instructorsService: InstructorsService,
   ) {}
 
+  private buildCourseConditions(input: SearchServiceInput) {
+    const courseConditions = [
+      ...buildGEQuery(input.ge),
+      ...buildDivisionQuery(input.courseLevel),
+      ...buildUnitBoundsQuery(course, input.minUnits, input.maxUnits),
+    ];
+
+    if (input.department) {
+      courseConditions.push(eq(course.department, input.department));
+    }
+
+    return and(...courseConditions);
+  }
+
   private async courseMappingFromResults(results: Map<string, number>) {
     return await this.coursesService
       .batchGetCourses(results.keys().toArray())
@@ -92,7 +107,7 @@ export class SearchService {
         rank: sql`TS_RANK(${COURSES_WEIGHTS}, ${query})`.mapWith(Number),
       })
       .from(course)
-      .where(sql`${COURSES_WEIGHTS} @@ ${query}`)
+      .where(and(this.buildCourseConditions(input), sql`${COURSES_WEIGHTS} @@ ${query}`))
       .orderBy((t) => [desc(t.rank), asc(t.id)])
       .then((rows) =>
         rows.reduce((acc, row) => acc.set(row.id, row.rank), new Map<string, number>()),
@@ -147,12 +162,14 @@ export class SearchService {
   }
 
   async doSearch(input: SearchServiceInput): Promise<z.infer<typeof searchResponseSchema>> {
-    if (input.resultType === "course") {
-      return this.doSearchForCourses(input);
-    }
     if (input.resultType === "instructor") {
       return this.doSearchForInstructors(input);
     }
+
+    if (input.resultType === "course") {
+      return this.doSearchForCourses(input);
+    }
+
     const query = toQuery(input.query);
     const results = await unionAll(
       this.db
@@ -162,7 +179,7 @@ export class SearchService {
           rank: sql`TS_RANK(${COURSES_WEIGHTS}, ${query})`.mapWith(Number),
         })
         .from(course)
-        .where(sql`${COURSES_WEIGHTS} @@ ${query}`),
+        .where(and(this.buildCourseConditions(input), sql`${COURSES_WEIGHTS} @@ ${query}`)),
       this.db
         .select({
           type: sql<SearchResultType>`'instructor'`,

--- a/apps/api/src/services/util.ts
+++ b/apps/api/src/services/util.ts
@@ -7,12 +7,12 @@ import type { z } from "zod";
 
 type WebsocServiceInput = z.infer<typeof websocQuerySchema>;
 
-type WebsocGELikeInput = Pick<WebsocServiceInput, "ge">;
-export function buildGEQuery(input: WebsocGELikeInput): Array<SQL | undefined> {
+type WebsocGELikeInput = WebsocServiceInput["ge"];
+export function buildGEQuery(ge: WebsocGELikeInput): Array<SQL | undefined> {
   const conditions = [];
 
-  if (input.ge) {
-    switch (input.ge) {
+  if (ge) {
+    switch (ge) {
       case "GE-1A":
         conditions.push(isTrue(websocCourse.isGE1A));
         break;
@@ -49,12 +49,12 @@ export function buildGEQuery(input: WebsocGELikeInput): Array<SQL | undefined> {
   return conditions;
 }
 
-type WebsocDivisionLikeInput = Pick<WebsocServiceInput, "division">;
-export function buildDivisionQuery(input: WebsocDivisionLikeInput): Array<SQL | undefined> {
+type WebsocDivisionLikeInput = WebsocServiceInput["division"];
+export function buildDivisionQuery(division: WebsocDivisionLikeInput): Array<SQL | undefined> {
   const conditions = [];
 
-  if (input.division) {
-    switch (input.division) {
+  if (division) {
+    switch (division) {
       case "LowerDiv":
         conditions.push(
           and(gte(websocCourse.courseNumeric, 1), lte(websocCourse.courseNumeric, 99)),
@@ -74,15 +74,15 @@ export function buildDivisionQuery(input: WebsocDivisionLikeInput): Array<SQL | 
   return conditions;
 }
 
-type WebsocMultiCourseNumberLikeInput = Pick<WebsocServiceInput, "courseNumber">;
+type WebsocMultiCourseNumberLikeInput = WebsocServiceInput["courseNumber"];
 export function buildMultiCourseNumberQuery(
-  input: WebsocMultiCourseNumberLikeInput,
+  courseNumber: WebsocMultiCourseNumberLikeInput,
 ): Array<SQL | undefined> {
   const conditions = [];
 
-  if (input.courseNumber) {
+  if (courseNumber) {
     const courseNumberConditions: Array<SQL | undefined> = [];
-    for (const num of input.courseNumber) {
+    for (const num of courseNumber) {
       switch (num._type) {
         case "ParsedInteger":
           courseNumberConditions.push(eq(websocCourse.courseNumeric, num.value));
@@ -103,7 +103,7 @@ export function buildMultiCourseNumberQuery(
   return conditions;
 }
 
-type WebsocDaysOfWeekLikeInput = Pick<WebsocServiceInput, "days">;
+type WebsocDaysOfWeekLikeInput = WebsocServiceInput["days"];
 interface WebsocMeetsLikeTable {
   meetsMonday: PgColumn<ColumnBaseConfig<"boolean", string>>;
   meetsTuesday: PgColumn<ColumnBaseConfig<"boolean", string>>;
@@ -115,13 +115,13 @@ interface WebsocMeetsLikeTable {
 }
 export function buildDaysOfWeekQuery(
   table: WebsocMeetsLikeTable,
-  input: WebsocDaysOfWeekLikeInput,
+  days: WebsocDaysOfWeekLikeInput,
 ): Array<SQL | undefined> {
   const conditions = [];
 
-  if (input.days) {
+  if (days) {
     const daysConditions: SQL[] = [];
-    for (const day of input.days) {
+    for (const day of days) {
       switch (day) {
         case "M":
           daysConditions.push(isTrue(table.meetsMonday));

--- a/apps/api/src/services/util.ts
+++ b/apps/api/src/services/util.ts
@@ -1,4 +1,4 @@
-import type { websocQuerySchema } from "$schema";
+import type { coursesQuerySchema, websocQuerySchema } from "$schema";
 import { type ColumnBaseConfig, type SQL, and, eq, gte, lte, or } from "@packages/db/drizzle";
 import type { PgColumn } from "@packages/db/drizzle-pg";
 import { websocCourse } from "@packages/db/schema";
@@ -147,6 +147,30 @@ export function buildDaysOfWeekQuery(
       }
     }
     conditions.push(or(...daysConditions));
+  }
+
+  return conditions;
+}
+
+type CoursesServiceInput = z.infer<typeof coursesQuerySchema>;
+
+interface CourseUnitsLikeTable {
+  minUnits: PgColumn<ColumnBaseConfig<"decimal", string>>;
+  maxUnits: PgColumn<ColumnBaseConfig<"decimal", string>>;
+}
+
+export function buildUnitBoundsQuery(
+  table: CourseUnitsLikeTable,
+  minUnits: CoursesServiceInput["minUnits"],
+  maxUnits: CoursesServiceInput["maxUnits"],
+): Array<SQL | undefined> {
+  const conditions = [];
+
+  if (minUnits) {
+    conditions.push(gte(table.minUnits, minUnits.toString(10)));
+  }
+  if (maxUnits) {
+    conditions.push(lte(table.maxUnits, maxUnits.toString(10)));
   }
 
   return conditions;

--- a/apps/api/src/services/websoc.ts
+++ b/apps/api/src/services/websoc.ts
@@ -39,14 +39,14 @@ function buildQuery(input: WebsocServiceInput) {
   const conditions = [
     and(eq(websocSchool.year, input.year), eq(websocSchool.quarter, input.quarter)),
   ];
-  conditions.push(...buildGEQuery(input));
+  conditions.push(...buildGEQuery(input.ge));
   if (input.department) {
     conditions.push(eq(websocDepartment.deptCode, input.department));
   }
   if (input.courseTitle) {
     conditions.push(eq(websocCourse.courseTitle, input.courseTitle));
   }
-  conditions.push(...buildMultiCourseNumberQuery(input));
+  conditions.push(...buildMultiCourseNumberQuery(input.courseNumber));
   if (input.sectionCodes) {
     const sectionCodesConditions: Array<SQL | undefined> = [];
     for (const code of input.sectionCodes) {
@@ -66,14 +66,14 @@ function buildQuery(input: WebsocServiceInput) {
   if (input.instructorName) {
     conditions.push(ilike(websocInstructor.name, `${input.instructorName}%`));
   }
-  conditions.push(...buildDaysOfWeekQuery(websocSectionMeeting, input));
+  conditions.push(...buildDaysOfWeekQuery(websocSectionMeeting, input.days));
   if (input.building) {
     conditions.push(eq(websocLocation.building, input.building.toUpperCase()));
   }
   if (input.room) {
     conditions.push(eq(websocLocation.room, input.room.toUpperCase()));
   }
-  conditions.push(...buildDivisionQuery(input));
+  conditions.push(...buildDivisionQuery(input.division));
   if (input.sectionType) {
     conditions.push(eq(websocSection.sectionType, input.sectionType));
   }


### PR DESCRIPTION
## Description
Allow for the filtering of searches involving courses (i.e. unified or course-only search, but not instructor search) along the following:

* Department offering course
* Course level (lower/upper/graduate)
* Min/max units
* GE category

Also adds `resultType` controlling the type of search to GraphQL variant of the endpoint.
The query building functions in `services/util.ts` have been adjusted slightly, leading to a slight footprint across other endpoints.

Blocked by #189.

## Related Issue

Closes #187.

## Screenshots (if appropriate):

The `department` filter successfully suppresses courses from other departments:
```
> curl "http://localhost:8787/v2/rest/search?query=aliens&resultType=course" 2>/dev/null | jq ".data.count"
3
> curl "http://localhost:8787/v2/rest/search?query=aliens&resultType=course&department=POL%20SCI" 2>/dev/null | jq ".data.count"
1
```

`resultType` on GraphQL functions successfully limits results:
```
> echo 'query Search {
    search(query: { query: "smith" }) {
        count
    }
}' \
| tr -d '\n' \
| jq --raw-input --raw-output --compact-output "{query: .}" \
| curl -s -X POST --data @- "http://localhost:8787/v2/graphql" -H "Content-Type: application/json" \
| jq ".data.search.count"
18

> echo 'query Search {
    search(query: { query: "smith", resultType: course }) {
        count
    }
}' \
| tr -d '\n' \
| jq --raw-input --raw-output --compact-output "{query: .}" \
| curl -s -X POST --data @- "http://localhost:8787/v2/graphql" -H "Content-Type: application/json" \
| jq ".data.search.count"
3
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
