### PR TITLE
fix: course scraper adjustment for "courseblock"  change

### DIFF
--- a/apps/data-pipeline/course-scraper/src/index.ts
+++ b/apps/data-pipeline/course-scraper/src/index.ts
@@ -7,7 +7,7 @@ import { database } from "@packages/db";
 import { desc, eq, inArray, or } from "@packages/db/drizzle";
 import type { CoursePrerequisite, Prerequisite, PrerequisiteTree } from "@packages/db/schema";
 import { course, prerequisite, websocDepartment, websocSchool } from "@packages/db/schema";
-import { sleep } from "@packages/stdlib";
+import { orNull, sleep } from "@packages/stdlib";
 import { load } from "cheerio";
 import fetch from "cross-fetch";
 import { hasChildren } from "domhandler";
@@ -69,8 +69,8 @@ const DEPT_TO_ALIAS = {
 
 type DeptAliasMap = typeof DEPT_TO_ALIAS;
 type DeptCode = keyof DeptAliasMap;
-const getDepartmentAlias = (dept: string): DeptAliasMap[DeptCode] | null =>
-  (DEPT_TO_ALIAS as Record<string, DeptAliasMap[DeptCode]>)[dept] ?? null;
+
+const getDepartmentAlias = (dept: string) => orNull(DEPT_TO_ALIAS[dept as DeptCode]);
 
 type ParseContext = {
   $: ReturnType<typeof load>;

--- a/apps/data-pipeline/course-scraper/src/index.ts
+++ b/apps/data-pipeline/course-scraper/src/index.ts
@@ -230,12 +230,6 @@ async function scrapePrerequisites() {
 
 const deepSortArray = <T extends unknown[]>(array: T): T => sortKeys(array, { deep: true });
 
-const courseMetaOrEmpty = (rawCourse: string[], key: string) =>
-  rawCourse
-    .find((x) => x.startsWith(key))
-    ?.replace(key, "")
-    .trim() ?? "";
-
 function generateGEs(rawCourse: string[]) {
   const maybeGEText = rawCourse.slice(-1)[0];
   const res = {
@@ -308,11 +302,10 @@ const textAfterLabel = (txt: string, label: string) => {
   return m ? stripFinalPeriod(m[1]) : "";
 };
 
-const parseUnitsStrict = (unitsText: string) => {
+const parseUnits = (unitsText: string) => {
   const raw = norm(unitsText)
     .replace(/Units?\./i, "Units")
     .replace(/Units?/i, "")
-    .replace(/[–—]/g, "-")
     .trim();
   if (raw.includes("-")) {
     const [lo, hi] = raw.split("-", 2).map((x) => x.trim());
@@ -373,7 +366,7 @@ async function scrapeCoursesInDepartment(meta: {
     const code = stripFinalPeriod(codeRaw);
     const title = stripFinalPeriod(titleRaw);
 
-    const { minUnits, maxUnits } = parseUnitsStrict(unitsRaw);
+    const { minUnits, maxUnits } = parseUnits(unitsRaw);
 
     const courseNumber = code.startsWith(deptCode) ? code.slice(deptCode.length).trim() : code;
     const courseNumeric = Number.parseInt(courseNumber.replace(/[A-Z]/g, ""), 10);

--- a/apps/data-pipeline/course-scraper/src/index.ts
+++ b/apps/data-pipeline/course-scraper/src/index.ts
@@ -11,6 +11,7 @@ import { sleep } from "@packages/stdlib";
 import { load } from "cheerio";
 import fetch from "cross-fetch";
 import { hasChildren } from "domhandler";
+import type { Element as DomElement } from "domhandler";
 import { diffString } from "json-diff";
 import readlineSync from "readline-sync";
 import sortKeys from "sort-keys";
@@ -226,17 +227,6 @@ const courseMetaOrEmpty = (rawCourse: string[], key: string) =>
     ?.replace(key, "")
     .trim() ?? "";
 
-const parseUnits = (unitString: string) =>
-  unitString.includes("-")
-    ? {
-        minUnits: unitFormatter.format(Number.parseFloat(unitString.split("-", 2)[0])),
-        maxUnits: unitFormatter.format(Number.parseFloat(unitString.split("-", 2)[1])),
-      }
-    : {
-        minUnits: unitFormatter.format(Number.parseFloat(unitString)),
-        maxUnits: unitFormatter.format(Number.parseFloat(unitString)),
-      };
-
 function generateGEs(rawCourse: string[]) {
   const maybeGEText = rawCourse.slice(-1)[0];
   const res = {
@@ -287,51 +277,6 @@ function generateGEs(rawCourse: string[]) {
   return res;
 }
 
-function parseRawCourse(meta: {
-  rawCourse: string[];
-  school: string;
-  department: string;
-  departmentName: string;
-  prereqs: Map<string, PrerequisiteTree> | undefined;
-  updatedAt: Date;
-}): typeof course.$inferInsert {
-  const { rawCourse, school, department, departmentName, prereqs, updatedAt } = meta;
-  const deptAndCourseNumber = rawCourse[0].trim().split(". ")[0].trim();
-  const title = rawCourse[0].trim().split(". ").slice(1, -1).join(". ").trim();
-  const units =
-    rawCourse[0]
-      .trim()
-      .split(". ")
-      .slice(2)
-      .slice(-1)[0]
-      ?.replace(/Units?\./, "")
-      .trim() ?? "0";
-  const courseNumber = deptAndCourseNumber.replace(department, "").trim();
-  const courseNumeric = Number.parseInt(courseNumber.replaceAll(/[A-Z]/g, ""), 10);
-  return {
-    id: deptAndCourseNumber.replaceAll(/ /g, ""),
-    department,
-    courseNumber,
-    school,
-    title,
-    courseLevel: courseNumeric < 100 ? "LowerDiv" : courseNumeric < 200 ? "UpperDiv" : "Graduate",
-    ...parseUnits(units),
-    description: rawCourse[1],
-    departmentName,
-    prerequisiteTree: prereqs?.get(deptAndCourseNumber) ?? {},
-    prerequisiteText: courseMetaOrEmpty(rawCourse, "Prerequisite: "),
-    repeatability: courseMetaOrEmpty(rawCourse, "Repeatability: "),
-    gradingOption: courseMetaOrEmpty(rawCourse, "Grading Option: "),
-    concurrent: courseMetaOrEmpty(rawCourse, "Concurrent with "),
-    sameAs: courseMetaOrEmpty(rawCourse, "Same as "),
-    restriction: courseMetaOrEmpty(rawCourse, "Restriction: "),
-    overlap: courseMetaOrEmpty(rawCourse, "Overlaps with "),
-    corequisites: courseMetaOrEmpty(rawCourse, "Corequisite: "),
-    ...generateGEs(rawCourse),
-    updatedAt,
-  };
-}
-
 const isPrereq = (x: Prerequisite | PrerequisiteTree): x is Prerequisite => "prereqType" in x;
 
 const prereqToString = (prereq: Prerequisite) =>
@@ -347,6 +292,33 @@ function prereqTreeToList(tree: PrerequisiteTree): string[] {
   return [];
 }
 
+const norm = (s: string) => s.replace(/\s+/g, " ").trim().normalize("NFKD");
+const stripFinalPeriod = (s: string) => s.replace(/\.\s*$/, "");
+const textAfterLabel = (txt: string, label: string) => {
+  const m = norm(txt).match(new RegExp(`^${label}s?:\\s*(.+)$`, "i"));
+  return m ? stripFinalPeriod(m[1]) : "";
+};
+
+const parseUnitsStrict = (unitsText: string) => {
+  const raw = norm(unitsText)
+    .replace(/Units?\./i, "Units")
+    .replace(/Units?/i, "")
+    .replace(/[–—]/g, "-")
+    .trim();
+  if (raw.includes("-")) {
+    const [lo, hi] = raw.split("-", 2).map((x) => x.trim());
+    return {
+      minUnits: unitFormatter.format(Number.parseFloat(lo)),
+      maxUnits: unitFormatter.format(Number.parseFloat(hi)),
+    };
+  }
+  const n = Number.parseFloat(raw || "0");
+  return {
+    minUnits: unitFormatter.format(n),
+    maxUnits: unitFormatter.format(n),
+  };
+};
+
 async function scrapeCoursesInDepartment(meta: {
   db: ReturnType<typeof database>;
   deptCode: string;
@@ -355,11 +327,14 @@ async function scrapeCoursesInDepartment(meta: {
 }) {
   const updatedAt = new Date();
   const { db, deptCode, deptPath, prereqs } = meta;
+
   if (!prereqs) {
     logger.warn(`${deptCode} does not have a prerequisite mapping.`);
     logger.warn("Prerequisite data for courses in this department will be empty.");
   }
+
   logger.info(`Scraping courses for ${deptCode}...`);
+
   const [school] = await db
     .select({ schoolName: websocSchool.schoolName, departmentName: websocDepartment.deptName })
     .from(websocSchool)
@@ -367,48 +342,98 @@ async function scrapeCoursesInDepartment(meta: {
     .where(eq(websocDepartment.deptCode, deptCode))
     .orderBy(desc(websocSchool.year))
     .limit(1);
+
   if (!school) {
     logger.warn(`Department ${deptCode} not found in WebSoc cache.`);
     logger.warn("The 'schoolName' field will be empty.");
   }
   const schoolName = school?.schoolName ?? "";
+
   const departmentText = await fetchWithDelay(`${CATALOGUE_URL}${deptPath}`);
   const $ = load(departmentText);
   const departmentName = $("h1.page-title").text().normalize("NFKD").split("(")[0].trim();
-  const courseText = $("div.courses")
-    .children()
-    .map(function () {
-      return $(this)
-        .text()
-        .split("\n")
-        .map((x) => x.trim().normalize("NFKD"))
-        .filter((x) => x.length)
-        .concat([""]);
-    })
-    .toArray()
-    .slice(3);
-  const rawCourses: string[][] = [];
-  let accumulator: string[] = [];
-  for (const line of courseText) {
-    if (!line.length) {
-      rawCourses.push([...accumulator]);
-      accumulator = [];
-      continue;
-    }
-    accumulator.push(line);
-  }
+
+  const toCourse = (el: DomElement): typeof course.$inferInsert | null => {
+    const $b = $(el);
+
+    const codeRaw = norm($b.find(".detail-code").first().text());
+    const titleRaw = norm($b.find(".detail-title").first().text());
+    const unitsRaw = norm($b.find(".detail-hours_html").first().text());
+    if (!codeRaw || !titleRaw || !unitsRaw) return null;
+
+    const code = stripFinalPeriod(codeRaw);
+    const title = stripFinalPeriod(titleRaw);
+
+    const { minUnits, maxUnits } = parseUnitsStrict(unitsRaw);
+
+    const courseNumber = code.startsWith(deptCode) ? code.slice(deptCode.length).trim() : code;
+    const courseNumeric = Number.parseInt(courseNumber.replace(/[A-Z]/g, ""), 10);
+    const courseLevel =
+      Number.isFinite(courseNumeric) && courseNumeric < 100
+        ? "LowerDiv"
+        : courseNumeric < 200
+          ? "UpperDiv"
+          : "Graduate";
+
+    const id = `${deptCode} ${courseNumber}`.replace(/ /g, "");
+
+    const desc = norm($b.find(".courseblockextra").first().text());
+    const prereqText = textAfterLabel($b.find(".detail-prereqs").first().text(), "Prerequisite");
+    const coreqText = textAfterLabel(
+      $b.find(".detail-coreqs, .detail-corequisites").first().text(),
+      "Corequisite",
+    );
+    const concText = textAfterLabel(
+      $b.find(".detail-concurrent").first().text(),
+      "Concurrent with",
+    );
+    const sameAsText = textAfterLabel($b.find(".detail-sameas").first().text(), "Same as");
+    const overlapText = textAfterLabel($b.find(".detail-overlaps").first().text(), "Overlaps with");
+    const restrText = textAfterLabel($b.find(".detail-restrictions").first().text(), "Restriction");
+    const gradingText = textAfterLabel(
+      $b.find(".detail-grading_option").first().text(),
+      "Grading Option",
+    );
+    const repeatText = textAfterLabel(
+      $b.find(".detail-repeatability").first().text(),
+      "Repeatability",
+    );
+    const geText = norm($b.find(".detail-gened").first().text());
+
+    const geFlags = generateGEs(geText ? [geText] : []);
+
+    return {
+      id,
+      department: deptCode,
+      courseNumber,
+      school: schoolName,
+      title,
+      courseLevel,
+      minUnits,
+      maxUnits,
+      description: desc || "",
+      departmentName,
+      prerequisiteTree: prereqs?.get(`${deptCode} ${courseNumber}`) ?? {},
+      prerequisiteText: prereqText,
+      repeatability: repeatText,
+      gradingOption: gradingText,
+      concurrent: concText,
+      sameAs: sameAsText,
+      restriction: restrText,
+      overlap: overlapText,
+      corequisites: coreqText,
+      ...geFlags,
+      updatedAt,
+    };
+  };
+
   const courses = deepSortArray(
-    rawCourses.map((rawCourse) =>
-      parseRawCourse({
-        rawCourse,
-        school: schoolName,
-        department: deptCode,
-        departmentName,
-        prereqs,
-        updatedAt,
-      }),
-    ),
+    $("div.courses .courseblock")
+      .toArray()
+      .map(toCourse)
+      .filter((x): x is NonNullable<typeof x> => !!x),
   );
+
   logger.info(`Fetching courses for ${deptCode} from database...`);
   const dbCourses = deepSortArray(
     await db
@@ -417,11 +442,12 @@ async function scrapeCoursesInDepartment(meta: {
       .where(
         inArray(
           course.id,
-          courses.map((course) => course.id),
+          courses.map((c) => c.id),
         ),
       )
       .then((rows) => rows.map(({ courseNumeric, updatedAt, ...rest }) => rest)),
   );
+
   const courseDiff = diffString(dbCourses, courses);
   if (!courseDiff.length) {
     logger.info(`No difference found between database and scraped course data for ${deptCode}.`);
@@ -433,20 +459,19 @@ async function scrapeCoursesInDepartment(meta: {
       exit(1);
     }
   }
+
   const prereqRows = deepSortArray(
     courses
-      .map((course) => ({
-        id: course.id,
-        prerequisiteList: prereqTreeToList(course.prerequisiteTree),
-      }))
-      .flatMap((course): (typeof prerequisite.$inferInsert)[] =>
-        course.prerequisiteList.map((prereq) => ({
-          prerequisiteId: prereq,
-          dependencyId: course.id,
+      .map((c) => ({ id: c.id, prerequisiteList: prereqTreeToList(c.prerequisiteTree) }))
+      .flatMap((c): (typeof prerequisite.$inferInsert)[] =>
+        c.prerequisiteList.map((p) => ({
+          prerequisiteId: p,
+          dependencyId: c.id,
           dependencyDept: deptCode,
         })),
       ),
   );
+
   logger.info(`Fetching prerequisites for ${deptCode} from database...`);
   const dbPrereqRows = deepSortArray(
     await db
@@ -455,11 +480,12 @@ async function scrapeCoursesInDepartment(meta: {
       .where(
         inArray(
           prerequisite.dependencyId,
-          prereqRows.map((prereq) => prereq.dependencyId),
+          prereqRows.map((r) => r.dependencyId),
         ),
       )
       .then((rows) => rows.map(({ id, ...rest }) => rest)),
   );
+
   const prereqDiff = diffString(dbPrereqRows, prereqRows);
   if (!prereqDiff.length) {
     logger.info(
@@ -473,23 +499,25 @@ async function scrapeCoursesInDepartment(meta: {
       exit(1);
     }
   }
+
   if (!courseDiff.length && !prereqDiff.length) {
     logger.info("Nothing to do.");
     return;
   }
+
   await db.transaction(async (tx) => {
     if (courses.length) {
       await tx.delete(course).where(
         inArray(
           course.id,
-          courses.map((course) => course.id),
+          courses.map((c) => c.id),
         ),
       );
       await tx.insert(course).values(courses);
       await tx.delete(prerequisite).where(
         inArray(
           prerequisite.dependencyId,
-          courses.map((course) => course.id),
+          courses.map((c) => c.id),
         ),
       );
       if (prereqRows.length) {
@@ -497,6 +525,7 @@ async function scrapeCoursesInDepartment(meta: {
       }
     }
   });
+
   logger.info(`Finished scraping courses for ${deptCode}`);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

rewrote `scrapeCoursesInDepartment` to parse per-course `.courseblock` elements and their `.detail-*` children instead of relying on newline-splitting. This matches the current catalogue HTML and removes brittleness around formatting changes.

also addressed missing `departmentAlias` in course by adding a mapping on completed scrape

## Related Issue

addresses #192, #193, #195, #152

## Motivation and Context

course scraper needs to be fixed to run for the 25/26 academic year

## How Has This Been Tested?

current testing status shows that entries for courses are accurately updated with the exception of `shortened_dept` and `department_alias`. shortened dept is addressed when running migration 10, but the setting of `department_alias` needs further investiagion

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
