### PR TITLE
fix(course-scraper): correct "same as"

### DIFF
--- a/apps/data-pipeline/course-scraper/src/index.ts
+++ b/apps/data-pipeline/course-scraper/src/index.ts
@@ -7,7 +7,7 @@ import { database } from "@packages/db";
 import { desc, eq, inArray, or } from "@packages/db/drizzle";
 import type { CoursePrerequisite, Prerequisite, PrerequisiteTree } from "@packages/db/schema";
 import { course, prerequisite, websocDepartment, websocSchool } from "@packages/db/schema";
-import { sleep } from "@packages/stdlib";
+import { orNull, sleep } from "@packages/stdlib";
 import { load } from "cheerio";
 import fetch from "cross-fetch";
 import { hasChildren } from "domhandler";
@@ -69,8 +69,8 @@ const DEPT_TO_ALIAS = {
 
 type DeptAliasMap = typeof DEPT_TO_ALIAS;
 type DeptCode = keyof DeptAliasMap;
-const getDepartmentAlias = (dept: string): DeptAliasMap[DeptCode] | null =>
-  (DEPT_TO_ALIAS as Record<string, DeptAliasMap[DeptCode]>)[dept] ?? null;
+
+const getDepartmentAlias = (dept: string) => orNull(DEPT_TO_ALIAS[dept as DeptCode]);
 
 type ParseContext = {
   $: ReturnType<typeof load>;

--- a/apps/data-pipeline/course-scraper/src/index.ts
+++ b/apps/data-pipeline/course-scraper/src/index.ts
@@ -230,12 +230,6 @@ async function scrapePrerequisites() {
 
 const deepSortArray = <T extends unknown[]>(array: T): T => sortKeys(array, { deep: true });
 
-const courseMetaOrEmpty = (rawCourse: string[], key: string) =>
-  rawCourse
-    .find((x) => x.startsWith(key))
-    ?.replace(key, "")
-    .trim() ?? "";
-
 function generateGEs(rawCourse: string[]) {
   const maybeGEText = rawCourse.slice(-1)[0];
   const res = {
@@ -308,11 +302,10 @@ const textAfterLabel = (txt: string, label: string) => {
   return m ? stripFinalPeriod(m[1]) : "";
 };
 
-const parseUnitsStrict = (unitsText: string) => {
+const parseUnits = (unitsText: string) => {
   const raw = norm(unitsText)
     .replace(/Units?\./i, "Units")
     .replace(/Units?/i, "")
-    .replace(/[–—]/g, "-")
     .trim();
   if (raw.includes("-")) {
     const [lo, hi] = raw.split("-", 2).map((x) => x.trim());
@@ -373,7 +366,7 @@ async function scrapeCoursesInDepartment(meta: {
     const code = stripFinalPeriod(codeRaw);
     const title = stripFinalPeriod(titleRaw);
 
-    const { minUnits, maxUnits } = parseUnitsStrict(unitsRaw);
+    const { minUnits, maxUnits } = parseUnits(unitsRaw);
 
     const courseNumber = code.startsWith(deptCode) ? code.slice(deptCode.length).trim() : code;
     const courseNumeric = Number.parseInt(courseNumber.replace(/[A-Z]/g, ""), 10);

--- a/apps/data-pipeline/course-scraper/src/index.ts
+++ b/apps/data-pipeline/course-scraper/src/index.ts
@@ -117,7 +117,7 @@ function parseCourseBlock(
     "Corequisite",
   );
   const concText = textAfterLabel($b.find(".detail-concurrent").first().text(), "Concurrent with");
-  const sameAsText = textAfterLabel($b.find(".detail-sameas").first().text(), "Same as");
+  const sameAsText = textAfterLabel($b.find(".detail-same_as").first().text(), "Same as");
   const overlapText = textAfterLabel($b.find(".detail-overlaps").first().text(), "Overlaps with");
   const restrText = textAfterLabel($b.find(".detail-restrictions").first().text(), "Restriction");
   const gradingText = textAfterLabel(


### PR DESCRIPTION
## Description

fix class selector not scraping "same as" properly from catalogue

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
