### PR TITLE
fix: added "overlap" scrape change to ensure validity

### DIFF
--- a/apps/data-pipeline/course-scraper/src/index.ts
+++ b/apps/data-pipeline/course-scraper/src/index.ts
@@ -118,7 +118,10 @@ function parseCourseBlock(
   );
   const concText = textAfterLabel($b.find(".detail-concurrent").first().text(), "Concurrent with");
   const sameAsText = textAfterLabel($b.find(".detail-same_as").first().text(), "Same as");
-  const overlapText = textAfterLabel($b.find(".detail-overlaps").first().text(), "Overlaps with");
+  const overlapText = textAfterLabel(
+    $b.find(".detail-overlaps_with").first().text(),
+    "Overlaps with",
+  );
   const restrText = textAfterLabel($b.find(".detail-restrictions").first().text(), "Restriction");
   const gradingText = textAfterLabel(
     $b.find(".detail-grading_option").first().text(),


### PR DESCRIPTION
overlap was not being documented due to an incorrect `courseblock` scrape

## Description



## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
