### PR TITLE
feat(degreeworks-scraper): discover and scrape only majors that exist 

### DIFF
--- a/apps/data-pipeline/degreeworks-scraper/package.json
+++ b/apps/data-pipeline/degreeworks-scraper/package.json
@@ -9,7 +9,9 @@
   },
   "dependencies": {
     "@packages/db": "workspace:*",
+    "@packages/stdlib": "workspace:*",
     "cross-fetch": "4.0.0",
-    "jwt-decode": "4.0.0"
+    "jwt-decode": "4.0.0",
+    "zod": "4.1.7"
   }
 }

--- a/apps/data-pipeline/degreeworks-scraper/src/components/DegreeworksClient.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/DegreeworksClient.ts
@@ -27,11 +27,10 @@ export class DegreeworksClient {
      * as the catalog year. Otherwise, we use the former.
      */
     const currentYear = new Date().getUTCFullYear();
-    dw.catalogYear = `${currentYear}${currentYear + 1}`;
-    const dataThisYear = await dw.getMajorAudit("BS", "U", "201").then((r) => r?.major);
-    if (!dataThisYear) {
-      dw.catalogYear = `${currentYear - 1}${currentYear}`;
-    }
+    const dataThisYear = await dw.getMajorAudit("BS", "U", "201");
+    dw.catalogYear = dataThisYear
+      ? `${currentYear}${currentYear + 1}`
+      : `${currentYear - 1}${currentYear}`;
     console.log(`[DegreeworksClient.new] Set catalogYear to ${dw.catalogYear}`);
     return dw;
   }

--- a/apps/data-pipeline/degreeworks-scraper/src/components/DegreeworksClient.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/DegreeworksClient.ts
@@ -27,7 +27,7 @@ export class DegreeworksClient {
      * as the catalog year. Otherwise, we use the former.
      */
     const currentYear = new Date().getUTCFullYear();
-    const dataThisYear = await dw.getMajorAudit("BS", "U", "201");
+    const dataThisYear = await dw.getMajorAudit("BS", "U", "201").then((r) => r?.major);
     dw.catalogYear = dataThisYear
       ? `${currentYear}${currentYear + 1}`
       : `${currentYear - 1}${currentYear}`;
@@ -75,11 +75,25 @@ export class DegreeworksClient {
     return [ucRequirements, geRequirements];
   }
 
+  /**
+   *
+   * @param degree a degree code, e.g. "BS"
+   * @param school this corresponds to the UCI notion of division, e.g. "U" or "G"
+   * @param majorCode a major code
+   * @param college this corresponds to the UCI notion of school, e.g. 55 for the school of bio sci
+   */
   async getMajorAudit(
     degree: string,
     school: string,
     majorCode: string,
-  ): Promise<Block | undefined> {
+    college?: string,
+  ): Promise<
+    | {
+        college?: Block;
+        major?: Block;
+      }
+    | undefined
+  > {
     const res = await fetch(DegreeworksClient.AUDIT_URL, {
       method: "POST",
       body: JSON.stringify({
@@ -88,17 +102,28 @@ export class DegreeworksClient {
         school,
         studentId: this.studentId,
         classes: [],
-        goals: [{ code: "MAJOR", value: majorCode }],
+        goals: [
+          { code: "MAJOR", value: majorCode },
+          ...(college ? [{ code: "COLLEGE", value: college }] : []),
+        ],
       }),
       headers: this.headers,
     });
     await this.sleep();
     const json: DWAuditResponse = await res.json().catch(() => ({ error: "" }));
-    return "error" in json
-      ? undefined
-      : json.blockArray.find(
-          (x) => x.requirementType === "MAJOR" && x.requirementValue === majorCode,
-        );
+
+    if ("error" in json) {
+      return undefined;
+    }
+
+    return {
+      college: json.blockArray.find(
+        (x) => x.requirementType === "COLLEGE" && x.requirementValue === college,
+      ),
+      major: json.blockArray.find(
+        (x) => x.requirementType === "MAJOR" && x.requirementValue === majorCode,
+      ),
+    };
   }
 
   async getMinorAudit(minorCode: string): Promise<Block | undefined> {

--- a/apps/data-pipeline/degreeworks-scraper/src/components/DegreeworksClient.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/DegreeworksClient.ts
@@ -27,10 +27,11 @@ export class DegreeworksClient {
      * as the catalog year. Otherwise, we use the former.
      */
     const currentYear = new Date().getUTCFullYear();
+    dw.catalogYear = `${currentYear}${currentYear + 1}`;
     const dataThisYear = await dw.getMajorAudit("BS", "U", "201").then((r) => r?.major);
-    dw.catalogYear = dataThisYear
-      ? `${currentYear}${currentYear + 1}`
-      : `${currentYear - 1}${currentYear}`;
+    if (!dataThisYear) {
+      dw.catalogYear = `${currentYear - 1}${currentYear}`;
+    }
     console.log(`[DegreeworksClient.new] Set catalogYear to ${dw.catalogYear}`);
     return dw;
   }

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -59,8 +59,14 @@ export class Scraper {
       .map(([k, _v]) => k);
   }
 
-  // note that the combination of major and degree is not unique, e.g. CSE, B.S.
-  // which is associated with both merage and bren
+  /**
+   * * The combination of school and major is not unique; Computer Science and Engineering is affiliated with two
+   * schools simultaneously.
+   * * It is not guaranteed that every triplet is valid; e.g. the Doctor of Pharmacy is mapped to two different objects
+   * on DegreeWorks, meaning one is not valid.
+   * * However, we operate under the assumption that every valid triplet is among the ones returned by this method.
+   * @private
+   */
   private async discoverValidDegrees(): Promise<ProgramTriplet[]> {
     const [awardTypes, reports] = await Promise.all([
       fetch("https://www.reg.uci.edu/mdsd/api/lookups/awardTypes").then((r) => r.json()),

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -110,11 +110,9 @@ export class Scraper {
           this.majorPrograms.has(ent.major.majorCode),
       )
       .flatMap((ent) =>
-        this.findDwNameFor(awardTypesMap, ent).map((dwName) => [
-          ent.school.schoolCode,
-          ent.major.majorCode,
-          dwName,
-        ]),
+        this.findDwNameFor(awardTypesMap, ent)
+          .map((dwName) => [ent.school.schoolCode, ent.major.majorCode, dwName])
+          .toArray(),
       );
   }
 

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -109,13 +109,13 @@ export class Scraper {
             new Date(`${ent.major.endTermYyyyst.slice(1)}-01-01`).getUTCFullYear() >= 2006) &&
           this.majorPrograms.has(ent.major.majorCode),
       )
-      .flatMap((ent) => {
-        const all = this.findDwNameFor(awardTypesMap, ent)
-          .map((dwName) => [ent.school.schoolCode, ent.major.majorCode, dwName])
-          .toArray();
-
-        return all;
-      });
+      .flatMap((ent) =>
+        this.findDwNameFor(awardTypesMap, ent).map((dwName) => [
+          ent.school.schoolCode,
+          ent.major.majorCode,
+          dwName,
+        ]),
+      );
   }
 
   private async scrapePrograms(degrees: Iterable<ProgramTriplet>) {

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -79,6 +79,7 @@ export class Scraper {
     const ret = new Map<string, DegreeWorksProgram>();
     for (const [schoolCode, majorCode, degreeCode] of degrees) {
       // todo: school blocks
+      // todo: humanities "liberal learnings"
       const audit = await this.dw.getMajorAudit(
         degreeCode,
         // bachelor's degrees probably get an abbreviation starting with B

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -62,8 +62,6 @@ export class Scraper {
   // note that the combination of major and degree is not unique, e.g. CSE, B.S.
   // which is associated with both merage and bren
   private async discoverValidDegrees(): Promise<ProgramTriplet[]> {
-    const validDegreeKeys = new Set(this.degrees.keys());
-
     const [awardTypes, reports] = await Promise.all([
       fetch("https://www.reg.uci.edu/mdsd/api/lookups/awardTypes").then((r) => r.json()),
       fetch("https://www.reg.uci.edu/mdsd/api/reports", {

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -119,38 +119,33 @@ export class Scraper {
   private async scrapePrograms(degrees: Iterable<ProgramTriplet>) {
     const ret = new Map<string, DegreeWorksProgram>();
     for (const [schoolCode, majorCode, degreeCode] of degrees) {
-      // todo: humanities "liberal learnings"
       const audit = await this.dw.getMajorAudit(
         degreeCode,
         // bachelor's degrees probably get an abbreviation starting with B
         degreeCode.startsWith("B") ? "U" : "G",
         majorCode,
-        schoolCode,
       );
 
-      const majorBlock = audit?.major;
-      if (!majorBlock) {
+      if (!audit) {
         console.log(
           `Requirements block not found (majorCode = ${majorCode}, degree = ${degreeCode})`,
         );
         continue;
       }
 
-      if (ret.has(majorBlock.title)) {
+      if (ret.has(audit.title)) {
         console.log(
-          `Requirements block already exists for "${majorBlock.title}" (majorCode = ${majorCode}, degree = ${degreeCode})`,
+          `Requirements block already exists for "${audit.title}" (majorCode = ${majorCode}, degree = ${degreeCode})`,
         );
         continue;
       }
       ret.set(
-        majorBlock.title,
-        await this.ap.parseBlock(`${schoolCode}-MAJOR-${majorCode}-${degreeCode}`, majorBlock),
+        audit.title,
+        await this.ap.parseBlock(`${schoolCode}-MAJOR-${majorCode}-${degreeCode}`, audit),
       );
       console.log(
-        `Requirements block found and parsed for "${majorBlock.title}" (majorCode = ${majorCode}, degree = ${degreeCode})`,
+        `Requirements block found and parsed for "${audit.title}" (majorCode = ${majorCode}, degree = ${degreeCode})`,
       );
-
-      // todo: handle school block
     }
     return ret;
   }

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -63,7 +63,8 @@ export class Scraper {
    * * The combination of school and major is not unique; Computer Science and Engineering is affiliated with two
    * schools simultaneously.
    * * It is not guaranteed that every triplet is valid; e.g. the Doctor of Pharmacy is mapped to two different objects
-   * on DegreeWorks, meaning one is not valid.
+   * on DegreeWorks, meaning one is not valid. We also include all triples valid in 2006 and later, where triples which
+   * were never valid while DegreeWorks was in use will most likely not be valid there.
    * * However, we operate under the assumption that every valid triplet is among the ones returned by this method.
    * @private
    */

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -113,12 +113,19 @@ export class Scraper {
             new Date(`${ent.major.endTermYyyyst.slice(1)}-01-01`).getUTCFullYear() >= 2006) &&
           this.majorPrograms.has(ent.major.majorCode),
       )
-      .flatMap(
-        (ent) =>
-          this.findDwNameFor(awardTypesMap, ent)
-            .map((dwName) => [ent.school.schoolCode, ent.major.majorCode, dwName])
-            .toArray() as ProgramTriplet[],
-      );
+      .flatMap((ent) => {
+        const withMatchedDegree = this.findDwNameFor(awardTypesMap, ent)
+          .map((dwName) => [ent.school.schoolCode, ent.major.majorCode, dwName])
+          .toArray() as ProgramTriplet[];
+
+        if (withMatchedDegree.length === 0) {
+          console.log(
+            `warning: no degree code matched for school and major (${ent.school.schoolCode}, ${ent.major.majorCode})`,
+          );
+        }
+
+        return withMatchedDegree;
+      });
   }
 
   private async scrapePrograms(degrees: Iterable<ProgramTriplet>) {

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -109,10 +109,11 @@ export class Scraper {
             new Date(`${ent.major.endTermYyyyst.slice(1)}-01-01`).getUTCFullYear() >= 2006) &&
           this.majorPrograms.has(ent.major.majorCode),
       )
-      .flatMap((ent) =>
-        this.findDwNameFor(awardTypesMap, ent)
-          .map((dwName) => [ent.school.schoolCode, ent.major.majorCode, dwName])
-          .toArray(),
+      .flatMap(
+        (ent) =>
+          this.findDwNameFor(awardTypesMap, ent)
+            .map((dwName) => [ent.school.schoolCode, ent.major.majorCode, dwName])
+            .toArray() as ProgramTriplet[],
       );
   }
 

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -119,13 +119,13 @@ export class Scraper {
   private async scrapePrograms(degrees: Iterable<ProgramTriplet>) {
     const ret = new Map<string, DegreeWorksProgram>();
     for (const [schoolCode, majorCode, degreeCode] of degrees) {
-      // todo: school blocks
       // todo: humanities "liberal learnings"
       const audit = await this.dw.getMajorAudit(
         degreeCode,
         // bachelor's degrees probably get an abbreviation starting with B
         degreeCode.startsWith("B") ? "U" : "G",
         majorCode,
+        schoolCode,
       );
 
       const majorBlock = audit?.major;
@@ -149,6 +149,8 @@ export class Scraper {
       console.log(
         `Requirements block found and parsed for "${majorBlock.title}" (majorCode = ${majorCode}, degree = ${degreeCode})`,
       );
+
+      // todo: handle school block
     }
     return ret;
   }

--- a/apps/data-pipeline/degreeworks-scraper/src/components/schema.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const reportsResponseSchema = z
+  .object({
+    id: z.int(),
+    school: z.object({
+      schoolCode: z.string(),
+    }),
+    major: z.object({
+      majorCode: z.string(),
+      // one-letter term then two-digit year, if present
+      endTermYyyyst: z.string().nullable(),
+      // the "active" field is true even on majors whose end term has passed and therefore must be ignored
+    }),
+    degree: z.object({
+      // teaching credentials, n-ple majors, undeclared, other misc do not have degree code
+      // we will ignore these since they are certainly out of scope for degreeworks, but
+      // it can happen at this stage
+      degreeCode: z.string().nullable(),
+    }),
+  })
+  .array();

--- a/apps/data-pipeline/degreeworks-scraper/src/components/schema.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/schema.ts
@@ -1,22 +1,29 @@
 import { z } from "zod";
 
-export const reportsResponseSchema = z
-  .object({
-    id: z.int(),
-    school: z.object({
-      schoolCode: z.string(),
-    }),
-    major: z.object({
-      majorCode: z.string(),
-      // one-letter term then two-digit year, if present
-      endTermYyyyst: z.string().nullable(),
-      // the "active" field is true even on majors whose end term has passed and therefore must be ignored
-    }),
-    degree: z.object({
-      // teaching credentials, n-ple majors, undeclared, other misc do not have degree code
-      // we will ignore these since they are certainly out of scope for degreeworks, but
-      // it can happen at this stage
-      degreeCode: z.string().nullable(),
-    }),
-  })
-  .array();
+export const rewardTypeSchema = z.object({
+  degreeCode: z.string(),
+  degreeShort: z.string(),
+});
+
+export const rewardTypesResponseSchema = rewardTypeSchema.array();
+
+export const reportSchema = z.object({
+  id: z.int(),
+  school: z.object({
+    schoolCode: z.string(),
+  }),
+  major: z.object({
+    majorCode: z.string(),
+    // one-letter term then two-digit year, if present
+    endTermYyyyst: z.string().nullable(),
+    // the "active" field is true even on majors whose end term has passed and therefore must be ignored
+  }),
+  degree: z.object({
+    // teaching credentials, n-ple majors, undeclared, other misc do not have this
+    // we will ignore these since they are certainly out of scope for degreeworks, but
+    // it can happen at this stage
+    degreeCode: z.string().nullable(),
+  }),
+});
+
+export const reportsResponseSchema = reportSchema.array();

--- a/apps/data-pipeline/degreeworks-scraper/src/components/schema.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/schema.ts
@@ -18,6 +18,9 @@ export const reportSchema = z.object({
     endTermYyyyst: z.string().nullable(),
     // the "active" field is true even on majors whose end term has passed and therefore must be ignored
   }),
+  // we don't need the department object because degreeworks does not allow a department to be selected,
+  // meaning a department could never impose requirements on a major which are not visible from the requirements of
+  // the major itself
   degree: z.object({
     // teaching credentials, n-ple majors, undeclared, other misc do not have this
     // we will ignore these since they are certainly out of scope for degreeworks, but

--- a/apps/data-pipeline/degreeworks-scraper/src/index.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/index.ts
@@ -18,9 +18,8 @@ async function main() {
     degreesAwarded,
     parsedUgradRequirements,
     parsedSpecializations,
-    parsedGradPrograms,
+    parsedPrograms,
     parsedMinorPrograms,
-    parsedUgradPrograms,
   } = scraper.get();
   const ucRequirementData = parsedUgradRequirements.get("UC");
   const geRequirementData = parsedUgradRequirements.get("GE");
@@ -33,15 +32,16 @@ async function main() {
       division: (id.startsWith("B") ? "Undergraduate" : "Graduate") as Division,
     }))
     .toArray();
-  const majorData = [...parsedUgradPrograms.values(), ...parsedGradPrograms.values()].map(
-    ({ name, degreeType, code, requirements }) => ({
+  const majorData = parsedPrograms
+    .values()
+    .map(({ name, degreeType, code, requirements }) => ({
       id: `${degreeType}-${code}`,
       degreeId: degreeType ?? "",
       code,
       name,
       requirements,
-    }),
-  );
+    }))
+    .toArray();
   const minorData = parsedMinorPrograms
     .values()
     .map(({ name, code: id, requirements }) => ({ id, name, requirements }))

--- a/apps/data-pipeline/degreeworks-scraper/src/types.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/types.ts
@@ -38,7 +38,7 @@ export type RuleIfStmt = {
   requirement: { ifPart: { ruleArray: Rule[] }; elsePart?: { ruleArray: Rule[] } };
 };
 /**
- * A rule that refers to another block (typically a specialization).
+ * A rule that refers to another block (typically a major mandating a specialization or school-wide requirements).
  */
 export type RuleBlock = {
   ruleType: "Block";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,12 +164,18 @@ importers:
       '@packages/db':
         specifier: workspace:*
         version: link:../../../packages/db
+      '@packages/stdlib':
+        specifier: workspace:*
+        version: link:../../../packages/stdlib
       cross-fetch:
         specifier: 4.0.0
         version: 4.0.0
       jwt-decode:
         specifier: 4.0.0
         version: 4.0.0
+      zod:
+        specifier: 4.1.7
+        version: 4.1.7
 
   apps/data-pipeline/grades-importer:
     dependencies:
@@ -464,12 +470,14 @@ packages:
 
   '@apollo/server-gateway-interface@1.1.1':
     resolution: {integrity: sha512-pGwCl/po6+rxRmDMFgozKQo2pbsSwE91TpsDBAOgf74CRDPXHHtM88wbwjab0wMMZh95QfR45GGyDIdhY24bkQ==}
+    deprecated: '@apollo/server-gateway-interface v1 is part of Apollo Server v4, which is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v2 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.'
     peerDependencies:
       graphql: 14.x || 15.x || 16.x
 
   '@apollo/server@4.11.0':
     resolution: {integrity: sha512-SWDvbbs0wl2zYhKG6aGLxwTJ72xpqp0awb2lotNpfezd9VcAvzaUizzKQqocephin2uMoaA8MguoyBmgtPzNWw==}
     engines: {node: '>=14.16.0'}
+    deprecated: Apollo Server v4 is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
     peerDependencies:
       graphql: ^16.6.0
 
@@ -4297,6 +4305,9 @@ packages:
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
+  zod@4.1.7:
+    resolution: {integrity: sha512-6qi6UYyzAl7W9uV29KvcSFXqK4QCYNYUz2YASPNBWpJE1RY6R1nArmmFPgGY/CBYWzpeMw3EOER+DR9a05O4IA==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -7850,3 +7861,5 @@ snapshots:
   zhead@2.2.4: {}
 
   zod@3.23.8: {}
+
+  zod@4.1.7: {}


### PR DESCRIPTION
This closes #156.

# What was done

We use the data backing the table at https://www.reg.uci.edu/mdsd/ to gather the list of valid "majors" at UCI. This term is used informally because it is a somewhat overloaded term. There are actually several parts to a major:

- The "school", with a unique code, e.g. Social Sciences.
- The "major", with a unique code, e.g. Cognitive Sciences.
- The "degree", with a unique code, e.g. B.S.

The combination of these three (and the correct department, but we don't need that for reasons explained in the code) forms the colloquial notion of a "major". Note that this also applies to graduate programs.

The identifiers describing schools and majors in this table align exactly with DegreeWorks. However, the degree code has no parallel in DegreeWorks. We instead attempt to matching using the name of the degree type e.g. B.S. or Ph.D. This is currently successful in all cases except one, where there is disagreement over the correct abbreviation for the Masters in Management.

Some entries are marked no longer active, meaning there would be no reason to attempt to find them on DegreeWorks. Since the least recently deactivated major in DegreeWorks is Applied Ecology at the end of 2006-2007, we can safely assume data from majors deactivated before 2006 won't be found.

## other stuff

The distinction between undergraduate and postgraduate "majors" has been removed since it does not serve a purpose right now. It can be re-added if it is determined to be relevant to a different task.

In pursuit of #167, this PR is also a limited pilot of Zod v4, which is used to validate responses from the aforementioned table. In the future we might want to validate DegreeWorks responses too.

# Results

Previously, we were brute-forcing valid combinations of the major code and degree type. This is obviously very inefficient. The number of requests necessary to obtain all valid undergraduate and postgraduate programs has been reduced from 7169 to 396 (on the 2024-2025 catalogue), which strongly correlates to a proportionate time speedup. The proportion of successful requests is increased from 4.5% to 77%.

It has been verified by external analysis of logs that all (major code, degree type) tuples successfully fetched by the current scraper but not the proposed one are misconfigured and do not correspond to meaningful data.