### PR TITLE
fix(degreeworks-scraper): correct catalogue year inference

### DIFF
--- a/apps/data-pipeline/degreeworks-scraper/src/components/DegreeworksClient.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/DegreeworksClient.ts
@@ -27,10 +27,11 @@ export class DegreeworksClient {
      * as the catalog year. Otherwise, we use the former.
      */
     const currentYear = new Date().getUTCFullYear();
+    dw.catalogYear = `${currentYear}${currentYear + 1}`;
     const dataThisYear = await dw.getMajorAudit("BS", "U", "201");
-    dw.catalogYear = dataThisYear
-      ? `${currentYear}${currentYear + 1}`
-      : `${currentYear - 1}${currentYear}`;
+    if (!dataThisYear) {
+      dw.catalogYear = `${currentYear - 1}${currentYear}`;
+    }
     console.log(`[DegreeworksClient.new] Set catalogYear to ${dw.catalogYear}`);
     return dw;
   }


### PR DESCRIPTION
This closes #212.

This is a simple fix exactly as specified by the issue; we properly attempt the scrape in the later academic year before evaluating whether we need to fall back to the earlier academic year.

The scraper in this PR correctly determines that the 2025-2026 catalogue is available on DegreeWorks as of right now, so this change works.