### PR TITLE
fix(degreeworks-scraper): infer specialization-major association

### DIFF
--- a/apps/data-pipeline/degreeworks-scraper/.gitignore
+++ b/apps/data-pipeline/degreeworks-scraper/.gitignore
@@ -1,0 +1,1 @@
+/spec_cache.json

--- a/apps/data-pipeline/degreeworks-scraper/.gitignore
+++ b/apps/data-pipeline/degreeworks-scraper/.gitignore
@@ -1,1 +1,1 @@
-/spec_cache.json
+/spec-cache-*.json

--- a/apps/data-pipeline/degreeworks-scraper/src/components/AuditParser.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/AuditParser.ts
@@ -28,7 +28,7 @@ export class AuditParser {
 
   lexOrd = new Intl.Collator().compare;
 
-  // as of this commit, this field has been removed
+  // as of this commit, this field is usually not provided
   // parseSpecs = (block: Block): string[] =>
   //   JSON.stringify(block)
   //     .matchAll(AuditParser.specOrOtherMatcher)

--- a/apps/data-pipeline/degreeworks-scraper/src/components/AuditParser.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/AuditParser.ts
@@ -22,17 +22,19 @@ export class AuditParser {
     ...this.parseBlockId(blockId),
     name: block.title,
     requirements: await this.ruleArrayToRequirements(block.ruleArray),
-    specs: this.parseSpecs(block),
+    // populate later
+    specs: [],
   });
 
   lexOrd = new Intl.Collator().compare;
 
-  parseSpecs = (block: Block): string[] =>
-    JSON.stringify(block)
-      .matchAll(AuditParser.specOrOtherMatcher)
-      .map((x) => JSON.parse(`{${x[0]}}`).value)
-      .toArray()
-      .sort();
+  // as of this commit, this field has been removed
+  // parseSpecs = (block: Block): string[] =>
+  //   JSON.stringify(block)
+  //     .matchAll(AuditParser.specOrOtherMatcher)
+  //     .map((x) => JSON.parse(`{${x[0]}}`).value)
+  //     .toArray()
+  //     .sort();
 
   flattenIfStmt(ruleArray: Rule[]): Rule[] {
     const ret = [];

--- a/apps/data-pipeline/degreeworks-scraper/src/components/DegreeworksClient.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/DegreeworksClient.ts
@@ -169,4 +169,8 @@ export class DegreeworksClient {
     const json: DWMappingResponse<T> = await res.json();
     return new Map(json._embedded[path].map((x) => [x.key, x.description]));
   }
+
+  getCatalogYear() {
+    return this.catalogYear;
+  }
 }

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -250,6 +250,7 @@ export class Scraper {
       const majorCandidates = this.specializationParentCandidates(specCode);
 
       let specBlock: Block | undefined;
+      let foundMajor: DegreeWorksProgram | undefined;
 
       for (const [candidateName, candidate] of majorCandidates) {
         if (!candidate.degreeType) throw new Error("Degree type is undefined");
@@ -262,10 +263,7 @@ export class Scraper {
         );
 
         if (specBlock) {
-          console.log(
-            `Specialization ${specName} (specCode = ${specCode}) found to be associated with ` +
-              `(majorCode = ${candidate.code}, degree = ${candidate.degreeType})`,
-          );
+          foundMajor = candidate;
           break;
         }
       }
@@ -287,13 +285,19 @@ export class Scraper {
           );
           if (try_) {
             specBlock = try_;
+            foundMajor = program;
             break;
           }
         }
       }
 
-      if (!specBlock) {
-        console.log(`todo ${specCode}`);
+      if (specBlock) {
+        console.log(
+          `Specialization ${specName} (specCode = ${specCode}) found to be associated with ` +
+            `(majorCode = ${(foundMajor as DegreeWorksProgram).code}, degree = ${(foundMajor as DegreeWorksProgram).degreeType})`,
+        );
+      } else {
+        console.log(`warning: no major associated with (specCode = ${specCode})`);
       }
     }
 

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -154,10 +154,11 @@ export class Scraper {
         );
         continue;
       }
-      ret.set(
-        audit.title,
-        await this.ap.parseBlock(`${schoolCode}-MAJOR-${majorCode}-${degreeCode}`, audit),
+      const block = await this.ap.parseBlock(
+        `${schoolCode}-MAJOR-${majorCode}-${degreeCode}`,
+        audit,
       );
+      ret.set(block.code, block);
       console.log(
         `Requirements block found and parsed for "${audit.title}" (majorCode = ${majorCode}, degree = ${degreeCode})`,
       );

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -37,7 +37,11 @@ export class Scraper {
   private parsedMinorPrograms = new Map<string, DegreeWorksProgram>();
   // both undergrad majors and grad programs
   private parsedPrograms = new Map<string, DegreeWorksProgram>();
-  private parsedSpecializations = new Map<string, [DegreeWorksProgramId, DegreeWorksProgram]>();
+  // (parent major, name, program object)
+  private parsedSpecializations = new Map<
+    string,
+    [DegreeWorksProgramId, string, DegreeWorksProgram]
+  >();
   private degreesAwarded = new Map<string, string>();
 
   private constructor() {}
@@ -346,6 +350,9 @@ export class Scraper {
 
         this.parsedSpecializations.set(specCode, [
           foundMajorAssured,
+          // don't use the block name because we would rather the display name be as it appears in the
+          // degreeworks dropdown, not the block title
+          specName,
           await this.ap.parseBlock(
             `${foundMajorAssured.school}-SPEC-${specCode}-${foundMajorAssured.degreeType}`,
             specBlock,
@@ -388,8 +395,8 @@ export class Scraper {
     // that it's probably not worth the effort to write a general solution.
 
     const x = this.parsedPrograms.get("Major in Art History") as DegreeWorksProgram;
-    const y = this.parsedSpecializations.get("AHGEO")?.[1] as DegreeWorksProgram;
-    const z = this.parsedSpecializations.get("AHPER")?.[1] as DegreeWorksProgram;
+    const y = this.parsedSpecializations.get("AHGEO")?.[2] as DegreeWorksProgram;
+    const z = this.parsedSpecializations.get("AHPER")?.[2] as DegreeWorksProgram;
     if (x && y && z) {
       x.specs = [];
       x.requirements = [...x.requirements, ...y.requirements, ...z.requirements];

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -266,9 +266,11 @@ export class Scraper {
 
       if (this.specializationCache.has(specCode)) {
         console.log(`found cached association for ${specCode}`);
-        const got = this.specializationCache.get(specCode) as NonNullable<SpecializationCache>;
-        specBlock = got.block;
-        foundMajor = got.parent;
+        const got = this.specializationCache.get(specCode) as SpecializationCache | null;
+        if (got !== null) {
+          specBlock = got.block;
+          foundMajor = got.parent;
+        }
       }
 
       if (!specBlock || !foundMajor) {

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -154,11 +154,13 @@ export class Scraper {
         );
         continue;
       }
+
       const block = await this.ap.parseBlock(
         `${schoolCode}-MAJOR-${majorCode}-${degreeCode}`,
         audit,
       );
       ret.set(block.code, block);
+
       console.log(
         `Requirements block found and parsed for "${audit.title}" (majorCode = ${majorCode}, degree = ${degreeCode})`,
       );

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -155,11 +155,10 @@ export class Scraper {
         continue;
       }
 
-      const block = await this.ap.parseBlock(
-        `${schoolCode}-MAJOR-${majorCode}-${degreeCode}`,
-        audit,
+      ret.set(
+        audit.title,
+        await this.ap.parseBlock(`${schoolCode}-MAJOR-${majorCode}-${degreeCode}`, audit),
       );
-      ret.set(block.code, block);
 
       console.log(
         `Requirements block found and parsed for "${audit.title}" (majorCode = ${majorCode}, degree = ${degreeCode})`,

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -261,7 +261,7 @@ export class Scraper {
     console.log("Scraping undergraduate and graduate program requirements");
     this.parsedPrograms = await this.scrapePrograms(validDegrees);
 
-    this.parsedSpecializations = new Map<string, DegreeWorksProgram>();
+    this.parsedSpecializations = new Map();
     console.log("Scraping all specialization requirements");
     const specCacheFilename = `spec-cache-${this.dw.getCatalogYear()}.json`;
     this.specializationCache = await fs

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -205,6 +205,8 @@ export class Scraper {
         .toArray();
     }
 
+    // no more heuristics; sorry, no candidates
+
     return [];
   }
 

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -301,7 +301,7 @@ export class Scraper {
         this.parsedSpecializations.set(
           specCode,
           await this.ap.parseBlock(
-            `${foundMajorAssured.school}-SPEC-${specCode}-${foundMajorAssured}`,
+            `${foundMajorAssured.school}-SPEC-${specCode}-${foundMajorAssured.degreeType}`,
             specBlock,
           ),
         );

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -270,7 +270,7 @@ export class Scraper {
 
       if (!specBlock) {
         console.log(
-          `warning: bruteforcing major associated with specialization ${specCode}: ${specName}`,
+          `warning: bruteforcing major associated with specialization "${specName}" (specCode = ${specCode})`,
         );
 
         // TODO: much more likely to have been an undergrad program; try those first
@@ -294,7 +294,7 @@ export class Scraper {
       if (specBlock) {
         const foundMajorAssured = foundMajor as DegreeWorksProgram;
         console.log(
-          `Specialization ${specName} (specCode = ${specCode}) found to be associated with ` +
+          `Specialization "${specName}" (specCode = ${specCode}) found to be associated with ` +
             `(majorCode = ${foundMajorAssured.code}, degree = ${foundMajorAssured.degreeType})`,
         );
 
@@ -310,7 +310,9 @@ export class Scraper {
           `Requirements block found and parsed for "${specBlock.title}" (specCode = ${specCode})`,
         );
       } else {
-        console.log(`warning: no known major associated with ${specName} (specCode = ${specCode})`);
+        console.log(
+          `warning: no known major associated with "${specName}" (specCode = ${specCode})`,
+        );
       }
     }
 

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -267,6 +267,7 @@ export class Scraper {
     this.specializationCache = await fs
       .readFile(specCacheFilename, {
         encoding: "utf-8",
+        // create if DNE, then open for reading + appending (but we care about reading)
         flag: "a+",
       })
       .then((s) => new Map(Object.entries(JSON.parse(s === "" ? "{}" : s))));

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -297,7 +297,7 @@ export class Scraper {
             `(majorCode = ${(foundMajor as DegreeWorksProgram).code}, degree = ${(foundMajor as DegreeWorksProgram).degreeType})`,
         );
       } else {
-        console.log(`warning: no major associated with (specCode = ${specCode})`);
+        console.log(`warning: no known major associated with (specCode = ${specCode})`);
       }
     }
 

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -175,12 +175,16 @@ export class Scraper {
    * @private
    */
   private inferSpecializationMajorCode(specCode: string): string | undefined {
-    // there seems to be a soft convention that specializations are their major ID followed by uppercase letters
+    // there seems to be a soft convention that specializations are their major code followed by uppercase letters
     // starting from A; let's try to use that first
 
-    const maybeMajorCodePart = specCode.slice(0, specCode.length - 1);
-    if (this.parsedPrograms.has(maybeMajorCodePart)) {
-      return maybeMajorCodePart;
+    const asSuffixedMajorCode = specCode.match(/^(.+)[A-Z]$/);
+
+    if (asSuffixedMajorCode) {
+      const [, maybeMajorCode] = asSuffixedMajorCode;
+      if (this.parsedPrograms.has(maybeMajorCode)) {
+        return maybeMajorCode;
+      }
     }
 
     return undefined;

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -247,16 +247,16 @@ export class Scraper {
     this.knownSpecializations = await this.dw.getMapping("specializations");
 
     for (const [specCode, specName] of this.knownSpecializations.entries()) {
-      const associatedMajorCode = this.specializationParentCandidates(specCode);
+      const majorCandidates = this.specializationParentCandidates(specCode);
 
       let specBlock: Block | undefined;
 
-      for (const [candidateName, candidate] of associatedMajorCode) {
+      for (const [candidateName, candidate] of majorCandidates) {
         if (!candidate.degreeType) throw new Error("Degree type is undefined");
 
         specBlock = await this.dw.getSpecAudit(
           candidate.degreeType,
-          candidate.school,
+          candidate.degreeType.startsWith("B") ? "U" : "G",
           candidate.code,
           specCode,
         );
@@ -281,7 +281,7 @@ export class Scraper {
 
           const try_ = await this.dw.getSpecAudit(
             program.degreeType,
-            program.school,
+            program.degreeType.startsWith("B") ? "U" : "G",
             program.code,
             specCode,
           );

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -297,7 +297,7 @@ export class Scraper {
             `(majorCode = ${(foundMajor as DegreeWorksProgram).code}, degree = ${(foundMajor as DegreeWorksProgram).degreeType})`,
         );
       } else {
-        console.log(`warning: no known major associated with (specCode = ${specCode})`);
+        console.log(`warning: no known major associated with ${specName} (specCode = ${specCode})`);
       }
     }
 

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -246,18 +246,12 @@ export class Scraper {
 
     this.knownSpecializations = await this.dw.getMapping("specializations");
 
-    const ugradPrograms = new Map<string, DegreeWorksProgram>();
-    const postGradPrograms = new Map<string, DegreeWorksProgram>();
-    for (const [key, prog] of this.parsedPrograms.entries()) {
-      (prog.degreeType?.startsWith("B") ? ugradPrograms : postGradPrograms).set(key, prog);
-    }
-
     for (const [specCode, specName] of this.knownSpecializations.entries()) {
       const associatedMajorCode = this.specializationParentCandidates(specCode);
 
       let specBlock: Block | undefined;
 
-      for (const [_candidateName, candidate] of associatedMajorCode) {
+      for (const [candidateName, candidate] of associatedMajorCode) {
         if (!candidate.degreeType) throw new Error("Degree type is undefined");
 
         specBlock = await this.dw.getSpecAudit(
@@ -281,14 +275,14 @@ export class Scraper {
           `warning: bruteforcing major associated with specialization ${specCode}: ${specName}`,
         );
 
-        // much more likely to have been an undergrad program
-        for (const [ugradProgramCode, ugradProgram] of ugradPrograms.entries()) {
-          if (!ugradProgram.degreeType) throw new Error("Degree type is undefined");
+        // TODO: much more likely to have been an undergrad program; try those first
+        for (const [programCode, program] of this.parsedPrograms.entries()) {
+          if (!program.degreeType) throw new Error("Degree type is undefined");
 
           const try_ = await this.dw.getSpecAudit(
-            ugradProgram.degreeType,
-            ugradProgram.school,
-            ugradProgram.code,
+            program.degreeType,
+            program.school,
+            program.code,
             specCode,
           );
           if (try_) {

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -37,7 +37,7 @@ export class Scraper {
   private parsedMinorPrograms = new Map<string, DegreeWorksProgram>();
   // both undergrad majors and grad programs
   private parsedPrograms = new Map<string, DegreeWorksProgram>();
-  private parsedSpecializations = new Map<string, DegreeWorksProgram>();
+  private parsedSpecializations = new Map<string, [DegreeWorksProgramId, DegreeWorksProgram]>();
   private degreesAwarded = new Map<string, string>();
 
   private constructor() {}
@@ -344,13 +344,13 @@ export class Scraper {
           block: specBlock,
         });
 
-        this.parsedSpecializations.set(
-          specCode,
+        this.parsedSpecializations.set(specCode, [
+          foundMajorAssured,
           await this.ap.parseBlock(
             `${foundMajorAssured.school}-SPEC-${specCode}-${foundMajorAssured.degreeType}`,
             specBlock,
           ),
-        );
+        ]);
 
         console.log(
           `Requirements block found and parsed for "${specBlock.title}" (specCode = ${specCode})`,
@@ -388,8 +388,8 @@ export class Scraper {
     // that it's probably not worth the effort to write a general solution.
 
     const x = this.parsedPrograms.get("Major in Art History") as DegreeWorksProgram;
-    const y = this.parsedSpecializations.get("AHGEO") as DegreeWorksProgram;
-    const z = this.parsedSpecializations.get("AHPER") as DegreeWorksProgram;
+    const y = this.parsedSpecializations.get("AHGEO")?.[1] as DegreeWorksProgram;
+    const z = this.parsedSpecializations.get("AHPER")?.[1] as DegreeWorksProgram;
     if (x && y && z) {
       x.specs = [];
       x.requirements = [...x.requirements, ...y.requirements, ...z.requirements];

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -309,27 +309,10 @@ export class Scraper {
       }
 
       if (newlyResolved && (!specBlock || !foundMajor)) {
-        console.log(
-          `warning: bruteforcing major associated with specialization "${specName}" (specCode = ${specCode})`,
-        );
+        console.log(`warning: no major associated with "${specName}" (specCode = ${specCode})`);
 
-        // TODO: much more likely to have been an undergrad program; try those first
-        for (const [programCode, program] of this.parsedPrograms.entries()) {
-          if (!program.degreeType) throw new Error("Degree type is undefined");
-
-          const try_ = await this.dw.getSpecAudit(
-            program.degreeType,
-            program.degreeType.startsWith("B") ? "U" : "G",
-            program.code,
-            specCode,
-          );
-
-          if (try_) {
-            specBlock = try_;
-            foundMajor = program;
-            break;
-          }
-        }
+        // if the convention of specialization codes being one letter appended to a major code is ever broken,
+        // we would need to bruteforce to find which major is associated with this spec
       }
 
       if (specBlock) {

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -298,6 +298,8 @@ export class Scraper {
             `(majorCode = ${foundMajorAssured.code}, degree = ${foundMajorAssured.degreeType})`,
         );
 
+        foundMajorAssured.specs.push(specCode);
+
         this.parsedSpecializations.set(
           specCode,
           await this.ap.parseBlock(

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -180,6 +180,14 @@ export class Scraper {
    * @private
    */
   private specializationParentCandidates(specCode: string): [string, DegreeWorksProgram][] {
+    // as of this commit, this spec is seemingly valid with any major but that's not really true
+    if (specCode === "OACSC") {
+      // "optional american chemical society certification"
+      const chemMajor = "Major in Chemistry";
+      const inMap = this.parsedPrograms.get(chemMajor);
+      return inMap ? [[chemMajor, inMap]] : [];
+    }
+
     // there seems to be a soft convention that specializations are their major code followed by uppercase letters
     // starting from A; let's try to use that first
 

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -276,7 +276,7 @@ export class Scraper {
         }
       }
 
-      if (!specBlock || !foundMajor) {
+      if (newlyResolved && (!specBlock || !foundMajor)) {
         const majorCandidates = this.specializationParentCandidates(specCode);
 
         for (const [candidateName, candidate] of majorCandidates) {
@@ -296,7 +296,7 @@ export class Scraper {
         }
       }
 
-      if (!specBlock || !foundMajor) {
+      if (newlyResolved && (!specBlock || !foundMajor)) {
         console.log(
           `warning: bruteforcing major associated with specialization "${specName}" (specCode = ${specCode})`,
         );

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -249,8 +249,9 @@ export class Scraper {
 
     this.parsedSpecializations = new Map<string, DegreeWorksProgram>();
     console.log("Scraping all specialization requirements");
+    const specCacheFilename = `spec-cache-${this.dw.getCatalogYear()}.json`;
     this.specializationCache = await fs
-      .readFile("spec_cache.json", {
+      .readFile(specCacheFilename, {
         encoding: "utf-8",
         flag: "a+",
       })
@@ -260,11 +261,6 @@ export class Scraper {
     this.knownSpecializations = await this.dw.getMapping("specializations");
 
     for (const [specCode, specName] of this.knownSpecializations.entries()) {
-      await fs.writeFile(
-        "spec_cache.json",
-        JSON.stringify(Object.fromEntries(this.specializationCache), undefined, 4),
-      );
-
       let specBlock: Block | undefined;
       let foundMajor: DegreeWorksProgramId | undefined;
 
@@ -353,6 +349,11 @@ export class Scraper {
 
         this.specializationCache.set(specCode, null);
       }
+
+      await fs.writeFile(
+        specCacheFilename,
+        JSON.stringify(Object.fromEntries(this.specializationCache), undefined, 4),
+      );
     }
 
     // TODO: optional specs e.g. ACM and chem

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -36,7 +36,7 @@ export class Scraper {
 
   private constructor() {}
 
-  // some degreeShort from catalogue do not agree the degreeworks version but really are the same
+  // some degreeShort from catalogue do not agree with the degreeworks version but really are the same
   private transformDegreeShort(input: string): string {
     return (
       {

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -263,10 +263,13 @@ export class Scraper {
     for (const [specCode, specName] of this.knownSpecializations.entries()) {
       let specBlock: Block | undefined;
       let foundMajor: DegreeWorksProgramId | undefined;
+      let newlyResolved = true;
 
       if (this.specializationCache.has(specCode)) {
         console.log(`found cached association for ${specCode}`);
         const got = this.specializationCache.get(specCode) as SpecializationCache | null;
+        newlyResolved = false;
+
         if (got !== null) {
           specBlock = got.block;
           foundMajor = got.parent;
@@ -352,10 +355,13 @@ export class Scraper {
         this.specializationCache.set(specCode, null);
       }
 
-      await fs.writeFile(
-        specCacheFilename,
-        JSON.stringify(Object.fromEntries(this.specializationCache), undefined, 4),
-      );
+      if (newlyResolved) {
+        // don't write to disk if we resolved this latest iteration from cache
+        await fs.writeFile(
+          specCacheFilename,
+          JSON.stringify(Object.fromEntries(this.specializationCache), undefined, 4),
+        );
+      }
     }
 
     // TODO: optional specs e.g. ACM and chem

--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -292,9 +292,22 @@ export class Scraper {
       }
 
       if (specBlock) {
+        const foundMajorAssured = foundMajor as DegreeWorksProgram;
         console.log(
           `Specialization ${specName} (specCode = ${specCode}) found to be associated with ` +
-            `(majorCode = ${(foundMajor as DegreeWorksProgram).code}, degree = ${(foundMajor as DegreeWorksProgram).degreeType})`,
+            `(majorCode = ${foundMajorAssured.code}, degree = ${foundMajorAssured.degreeType})`,
+        );
+
+        this.parsedSpecializations.set(
+          specCode,
+          await this.ap.parseBlock(
+            `${foundMajorAssured.school}-SPEC-${specCode}-${foundMajorAssured}`,
+            specBlock,
+          ),
+        );
+
+        console.log(
+          `Requirements block found and parsed for "${specBlock.title}" (specCode = ${specCode})`,
         );
       } else {
         console.log(`warning: no known major associated with ${specName} (specCode = ${specCode})`);
@@ -303,27 +316,6 @@ export class Scraper {
 
     // TODO: optional specs e.g. ACM and chem
 
-    // for (const [, {specs, school, code: majorCode, degreeType: degree}] of [
-    //   ...this.parsedPrograms
-    // ]) {
-    //   if (!degree) throw new Error("Degree type is undefined");
-    //   for (const specCode of specs) {
-    //     const audit = await this.dw.getSpecAudit(degree, school, majorCode, specCode);
-    //     if (!audit) {
-    //       console.log(
-    //         `Requirements block not found (school = ${school}, majorCode = ${majorCode}, specCode = ${specCode}, degree = ${degree})`,
-    //       );
-    //       continue;
-    //     }
-    //     this.parsedSpecializations.set(
-    //       specCode,
-    //       await this.ap.parseBlock(`${school}-SPEC-${specCode}-${degree}`, audit),
-    //     );
-    //     console.log(
-    //       `Requirements block found and parsed for "${audit.title}" (specCode = ${specCode})`,
-    //     );
-    //   }
-    // }
     this.degreesAwarded = new Map(
       Array.from(new Set(this.parsedPrograms.entries().map(([, x]) => x.degreeType ?? ""))).map(
         (x): [string, string] => [x, this.degrees?.get(x) ?? ""],

--- a/apps/data-pipeline/degreeworks-scraper/src/index.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/index.ts
@@ -48,10 +48,10 @@ async function main() {
     .toArray();
   const specData = parsedSpecializations
     .values()
-    .map(([majorId, { name, degreeType, code, requirements }]) => ({
+    .map(([majorId, specName, { name, degreeType, code, requirements }]) => ({
       id: `${degreeType}-${code}`,
+      name: specName,
       majorId: `${majorId.degreeType}-${majorId.code}`,
-      name,
       requirements,
     }))
     .toArray();

--- a/apps/data-pipeline/degreeworks-scraper/src/index.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/index.ts
@@ -48,9 +48,9 @@ async function main() {
     .toArray();
   const specData = parsedSpecializations
     .values()
-    .map(({ name, degreeType, code, requirements }) => ({
+    .map(([majorId, { name, degreeType, code, requirements }]) => ({
       id: `${degreeType}-${code}`,
-      majorId: `${degreeType}-${code.slice(0, code.length - 1)}`,
+      majorId: `${majorId.degreeType}-${majorId.code}`,
       name,
       requirements,
     }))

--- a/apps/data-pipeline/degreeworks-scraper/src/types.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/types.ts
@@ -1,3 +1,5 @@
+import type { DegreeWorksProgramId } from "@packages/db/schema";
+
 /**
  * The base type for all `Rule` objects.
  */
@@ -84,4 +86,10 @@ export type DWAuditResponse = DWAuditOKResponse | DWAuditErrorResponse;
 
 export type DWMappingResponse<T extends string> = {
   _embedded: { [P in T]: { key: string; description: string }[] };
+};
+
+// this is the data we cache on a specialization, if it is valid
+export type SpecializationCache = {
+  parent: DegreeWorksProgramId;
+  block: Block;
 };


### PR DESCRIPTION
Closes #209.
See the description there for our motivation.

Instead of looking at the list of specializations in a major (which is no longer consistently provided), we look at the list of overall specializations and try to match each one to a major.
Some specializations do not match with any major at all. The only way to resolve this is to attempt every combination of specialization and major; valid combinations return the specialization block.

Upon analysis, there does seem to be some method to the madness.
The previous soft convention associating specialization code with their respective major code still appears intact.

This is also progress toward #210 because the list of specializations previously provided was given as advice when a specialization was not selected for a major which requires one. In essence, we were previously totally unaware of optional specializations, but we now scrape and store them, resulting in the "discovery" of 25 more specializations. We're still missing the part where we figure out whether specializations are optional.

In case the aforementioned bruteforcing (over hundreds of majors) is necessary in the future, and for the benefit of allowing partial scraping, specialization associations are cached to disk per catalogue year (it is assumed that these associations won't change per catalogue year). Any attempt at finding the major associated with a specialization (including concluding that there is no associated major) is skipped if the result of an earlier attempt is already in the cache.

The name associated with a specialization in the database has changed to its name in the specializations mapping, instead of the title of its block. This is done primarily so that the name given to *e.g.* PeterPortal agrees with the name seen in the DegreeWorks dropdown menu.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.