### PR TITLE
fix: explicit check for missing value in year schema

### DIFF
--- a/apps/api/src/schema/lib/year.ts
+++ b/apps/api/src/schema/lib/year.ts
@@ -6,10 +6,10 @@ import { z } from "@hono/zod-openapi";
 
 export const yearSchema = z.coerce
   .string()
-  .refine((val: string) => val !== "null" && val !== "undefined", {
+  .refine((val) => val !== "null" && val !== "undefined", {
     message: "Parameter 'year' is required",
   })
-  .refine((val: string) => /^\d{4}$/.test(val), {
+  .refine((val) => /^\d{4}$/.test(val), {
     message: "Year must be a 4-digit positive integer",
   })
   .openapi({ example: "2024" });

--- a/apps/api/src/schema/lib/year.ts
+++ b/apps/api/src/schema/lib/year.ts
@@ -6,7 +6,7 @@ import { z } from "@hono/zod-openapi";
 
 export const yearSchema = z.coerce
   .string()
-  .refine((val: string) => val !== "" && val !== "null" && val !== "undefined", {
+  .refine((val: string) => val !== "null" && val !== "undefined", {
     message: "Parameter 'year' is required",
   })
   .refine((val: string) => /^\d{4}$/.test(val), {

--- a/apps/api/src/schema/lib/year.ts
+++ b/apps/api/src/schema/lib/year.ts
@@ -6,10 +6,10 @@ import { z } from "@hono/zod-openapi";
 
 export const yearSchema = z.coerce
   .string()
-  .refine((val) => val !== ("" || "undefined" || "null"), {
+  .refine((val: string) => val !== "" && val !== "null" && val !== "undefined", {
     message: "Parameter 'year' is required",
   })
-  .refine((val) => /^\d{4}$/.test(val), {
+  .refine((val: string) => /^\d{4}$/.test(val), {
     message: "Year must be a 4-digit positive integer",
   })
   .openapi({ example: "2024" });


### PR DESCRIPTION
## Description
Solved issue #94 by explicitly comparing val to the empty string, null and undefined

## How Has This Been Tested?
Ran null, undefined, and empty string through localhost. Results in screenshots

## Screenshots
<img width="2783" height="813" alt="image" src="https://github.com/user-attachments/assets/36f1254d-e6ca-4217-b106-a7f0dbc9f3f8" />
<img width="2781" height="808" alt="image" src="https://github.com/user-attachments/assets/fe9edf13-15ef-4645-965c-f3ec12a86400" />
<img width="2780" height="802" alt="image" src="https://github.com/user-attachments/assets/4911ef55-a738-4e94-9daa-eebab61f0b0a" />

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.

