### PR TITLE
fix(degreeworks-scraper): incorrect construction of new database entity

### DIFF
--- a/apps/data-pipeline/degreeworks-scraper/src/index.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/index.ts
@@ -144,7 +144,7 @@ async function main() {
 
     for (const majorObj of majorData) {
       if (majorObj.collegeBlockIndex !== undefined) {
-        (majorObj as typeof major.$inferInsert).college =
+        (majorObj as typeof major.$inferInsert).collegeRequirement =
           collegeBlockIds[majorObj.collegeBlockIndex];
       }
     }


### PR DESCRIPTION
Fixes issue introduced in #183.
This is a simple typo.
This only affects the first stage of ETL, so existing SQL rows, including those in production, continue to be accessible as if this issue did not exist.

