### PR TITLE
feat(ci): type check all deploying workflows

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Type check
+        run: pnpm check:types
+
       - name: Run database migrations
         working-directory: ./packages/db
         run: pnpm run migrate

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Type check
+        run: pnpm check:types
+
       - name: Deploy API to staging
         working-directory: ./apps/api
         run: pnpm run deploy --name=anteater-api-staging-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Closes #228.

Immdiately after dependency installation, a new step is added in the workflows to deploy to production (as of writing, pushes to `main`) and staging (as of writing, approved pull request branches).
This simply runs our existing `check:types` task.

