### PR TITLE
fix: update AP exam endpoint metadata to reflect reward data

### DIFF
--- a/apps/api/src/rest/routes/ap-exams.ts
+++ b/apps/api/src/rest/routes/ap-exams.ts
@@ -16,13 +16,13 @@ const apExamsRouter = new OpenAPIHono<{ Bindings: Env }>({ defaultHook });
 apExamsRouter.openAPIRegistry.register("coursesGrantedTree", coursesGrantedTreeSchema);
 
 const apExamsRoute = createRoute({
-  summary: "Retrieve AP Exam names",
+  summary: "Retrieve AP Exam data and rewards",
   operationId: "apExams",
   tags: ["AP Exams"],
   method: "get",
   path: "/",
   description:
-    "Get a mapping from AP exam names as they appear in the UCI Catalogue to their official names as given by College Board",
+    "Get AP exam data including name mappings from UCI Catalogue to College Board names, along with reward information such as units granted, GE categories, and course credit for different exam scores.",
   request: { query: apExamsQuerySchema },
   responses: {
     200: {


### PR DESCRIPTION
## Description
Update OpenAPI metadata for AP exam endpoint to accurately reflect the endpoint's functionality.

The current OpenAPI description only mentions name mappings, but the endpoint actually returns comprehensive reward data including units granted, GE categories, and course credit information.

## Related Issue
Fixes #216

## Motivation and Context
The AP exam endpoint's OpenAPI metadata was outdated, only describing name mappings from UCI Catalogue to College Board names. However, the endpoint actually provides much more data including reward information for different exam scores.

## How Has This Been Tested?
- Tested locally with the development server
- Verified OpenAPI documentation now shows accurate description

## Changes Made
- Updated summary from "Retrieve AP Exam names" to "Retrieve AP Exam data and rewards"
- Updated description to mention both name mappings AND reward information (units granted, GE categories, course credit)

##Screenshots (if appropriate):
<img width="2486" height="1030" alt="AP_Exams_MetaData_Update" src="https://github.com/user-attachments/assets/fda9e1ca-3133-45fb-8def-91d6a4722632" />


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code involves a change to the database schema.
- [x] My code requires a change to the documentation.