### PR TITLE
fix: use orNull utility to standardize falsy-to-null conversions

### DIFF
--- a/apps/api/src/services/programs.ts
+++ b/apps/api/src/services/programs.ts
@@ -124,11 +124,7 @@ export class ProgramsService {
       .where(eq(table.id, query.programId))
       .limit(1);
 
-    if (!got) {
-      return null;
-    }
-
-    return got;
+    return orNull(got);
   }
 
   async getUgradRequirements(query: z.infer<typeof ugradRequirementsQuerySchema>) {


### PR DESCRIPTION
This pull request makes a small change to the `ProgramsService` class to simplify how null values are returned. The code now uses the `orNull` utility to handle cases where no result is found, making the code cleaner and more consistent.

- Simplified null return logic in the `getById` method by using the `orNull` helper instead of a manual check.

## Related Issue

#109 