### PR TITLE
fix: AP Exam reward tree type isn't consistent

### DIFF
--- a/apps/api/src/schema/ap-exams.ts
+++ b/apps/api/src/schema/ap-exams.ts
@@ -27,11 +27,14 @@ export const coursesGrantedTreeSchema: z.ZodType<APCoursesGrantedTree> = z
   })
   .or(
     z.object({
-      OR: z.union([z.lazy(() => coursesGrantedTreeSchema).array(), z.string().array()]).openapi({
-        description: "Any one of these entries is granted",
-        type: "array",
-        items: { $ref: "#/components/schemas/coursesGrantedTree" },
-      }),
+      OR: z
+        .union([z.lazy(() => coursesGrantedTreeSchema), z.string()])
+        .array()
+        .openapi({
+          description: "Any one of these entries is granted",
+          type: "array",
+          items: { $ref: "#/components/schemas/coursesGrantedTree" },
+        }),
     }),
   );
 


### PR DESCRIPTION
Fixes AP Exam reward tree type consistency

## Description

Fixed it :)

## Related Issue

https://github.com/icssc/anteater-api/issues/245

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
