### PR TITLE
fix: add missing tags for Programs and Study Rooms to OpenAPI metadata

### DIFF
--- a/apps/api/src/middleware/openapi-meta.ts
+++ b/apps/api/src/middleware/openapi-meta.ts
@@ -59,7 +59,7 @@ export const openapiMeta: OpenAPIObjectConfigure<{ Bindings: Env }, string> = {
     {
       name: "Study Rooms",
       description:
-        "Data sourced from UCI Libraries' reservation site (https://spaces.lib.uci.edu/).",
+        "Data sourced from the UCI Libraries reservation site (https://spaces.lib.uci.edu/).",
     },
     { name: "AP Exams", description: "Data concerning AP Exams as they relate to UCI." },
     { name: "Other" },


### PR DESCRIPTION
## Description

The "Programs" and "Study Rooms" tags were added to the tags list within openapi-meta.ts such that they now have a description and specified order. 

## Related Issue

[124](https://github.com/icssc/anteater-api/issues/124)

## Motivation and Context

The OpenAPI metadata file at apps/api/src/middleware/openapi-meta.ts defines the application-wide OpenAPI spec. The metadata for tags gives the names and descriptions of the route tags, as well as defining their ordering. The current implementation leaves the "Programs" and "Study Rooms" tags with no description or defined order. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran the changes locally using ```pnpm dev```. Verified that the new tags were correctly added to the /openapi.json endpoint and in the reference docs on the local server. 

## Screenshots (if appropriate):

<img width="277" height="443" alt="Screenshot 2025-11-15 at 4 17 16 PM" src="https://github.com/user-attachments/assets/e1b861fd-18b2-4638-998e-45ebf1fba5af" />

<img width="1419" height="453" alt="Screenshot 2025-11-15 at 4 17 33 PM" src="https://github.com/user-attachments/assets/f4320e81-89d5-48af-9cf5-ceb18e8b1e9f" />

<img width="1416" height="339" alt="Screenshot 2025-11-15 at 4 17 50 PM" src="https://github.com/user-attachments/assets/63183c68-68f9-40cc-84ba-4317274ec354" />

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
