### PR TITLE
fix: use word boundaries in GE category regex patterns to correct GE category extraction

### DIFF
--- a/apps/data-pipeline/course-scraper/src/index.ts
+++ b/apps/data-pipeline/course-scraper/src/index.ts
@@ -345,34 +345,34 @@ function generateGEs(rawCourse: string[]) {
   };
   if (!maybeGEText?.startsWith("(")) return res;
   res.geText = maybeGEText;
-  if (res.geText.match(/I[Aa]/)) {
+  if (res.geText.match(/\bI[Aa]\b/)) {
     res.isGE1A = true;
   }
-  if (res.geText.match(/I[Bb]/)) {
+  if (res.geText.match(/\bI[Bb]\b/)) {
     res.isGE1B = true;
   }
-  if (res.geText.match(/[( ]II[) ]/)) {
+  if (res.geText.match(/\bII\b/)) {
     res.isGE2 = true;
   }
-  if (res.geText.match(/[( ]III[) ]/)) {
+  if (res.geText.match(/\bIII\b/)) {
     res.isGE3 = true;
   }
-  if (res.geText.match(/IV/)) {
+  if (res.geText.match(/\bIV\b/)) {
     res.isGE4 = true;
   }
-  if (res.geText.match(/V\.?[Aa]/)) {
+  if (res.geText.match(/\bV\.?[Aa]\b/)) {
     res.isGE5A = true;
   }
-  if (res.geText.match(/V\.?[Bb]/)) {
+  if (res.geText.match(/\bV\.?[Bb]\b/)) {
     res.isGE5B = true;
   }
-  if (res.geText.match(/[( ]VI[) ]/)) {
+  if (res.geText.match(/\bVI\b/)) {
     res.isGE6 = true;
   }
-  if (res.geText.match(/[( ](VII)[) ]/)) {
+  if (res.geText.match(/\bVII\b/)) {
     res.isGE7 = true;
   }
-  if (res.geText.match(/VIII/)) {
+  if (res.geText.match(/\bVIII\b/)) {
     res.isGE8 = true;
   }
   return res;


### PR DESCRIPTION
This PR changes the regex patterns to use word boundaries to correctly extract GE categories from a string containing a mix of categories and punctuation like parentheses and periods.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Updated all GE category regex patterns in the course scraper to use word boundaries (\b) instead of restrictive character class patterns. This fixes an issue where GE categories followed by punctuation (periods, commas, etc.) were not being detected correctly.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/icssc/anteater-api/issues/262

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The previous regex patterns required specific characters before and after Roman numerals (spaces or parentheses), which failed when the catalogue included punctuation directly after the numeral. This caused courses to be missing when getting courses from the API with the geCategory URL parameter. Word boundaries (\b) match the transition between word characters (letters) and non-word characters (spaces, punctuation, etc.), regardless of what specific punctuation is used.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Ran the course scraper on all departments with the updated regex patterns
2. Verified database updates for affected courses:
    - Confirmed I&C SCI 11 now has GE3 (previously missing)
    - Confirmed AFAM 40A now has GE7 (previously missing)
3. Tested edge cases to ensure no false positives:
    - Verified III doesn't match to II
    - Verified VIII doesn't match III
    - Verified patterns work with various formats: "(III.)", "(II or III)", "((III or IV) and VII.)"

## Screenshots (if appropriate):

<img width="1306" height="497" alt="image" src="https://github.com/user-attachments/assets/745e8b47-f1ca-4c9d-8eb7-a4e3dfa37c20" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
