### PR TITLE
programs: Add blockId to requirements object

### DIFF
--- a/apps/data-pipeline/degreeworks-scraper/src/types.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/types.ts
@@ -3,7 +3,13 @@ import type { DegreeWorksProgramId } from "@packages/db/schema";
 /**
  * The base type for all `Rule` objects.
  */
-export type RuleBase = { label: string };
+export type RuleBase = {
+  label: string;
+  labelTag: string;
+  ruleType: string;
+  ruleId: string;
+  nodeId: string;
+};
 /**
  * A group of `numberOfRules` rules,
  * of which `numberOfGroups` must be satisfied

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -127,7 +127,10 @@ export type DegreeWorksMarkerRequirement = {
   requirementType: "Marker";
 };
 
-export type DegreeWorksRequirementBase = { label: string };
+export type DegreeWorksRequirementBase = {
+  label: string;
+  requirementId: string;
+};
 
 export type DegreeWorksRequirement = DegreeWorksRequirementBase &
   (


### PR DESCRIPTION
## Description
`blockId` was added to the `requirements` json at every level, similar to `label`, by updating the parser.

## Related Issue
https://github.com/icssc/anteater-api/issues/185

## Motivation and Context
We define a blockId composed of:
- School code (U / G)
- Program type (COLLEGE / MAJOR / MINOR / SPEC)
- id code
- degree type (BS / BA, etc.)

Please note that, at the moment, we provide the same blockId for every level within a block. Additionally, COLLEGE programs don't have a defined blockId at the moment.

## How Has This Been Tested?
The change reflects in the `requirements` column of `major`, `minor`, and `specialization` tables, after running the DegreeWorks scraper.

## Screenshots (if appropriate):\
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code involves a change to the database schema.
- [X] My code requires a change to the documentation.
