### PR TITLE
docs: openapi description typo

### DIFF
--- a/apps/api/src/middleware/openapi-meta.ts
+++ b/apps/api/src/middleware/openapi-meta.ts
@@ -6,7 +6,7 @@ export const openapiMeta: OpenAPIObjectConfigure<{ Bindings: Env }, string> = {
     version: "2.0.0",
     title: "Anteater API",
     description:
-      "The unified API for UCI related data. View documentation at https://docs.icssc.club/docs/developer/anteaterapi and API reference at https://anteaterapi.com/reference.\n\nWhile all data from this API is derived from official UCI sources, we cannot guarantee its accuracy. However, we do take data accuracy very seriously, and we urge you to report any discrepencies at https://github.com/icssc/anteater-api/issues.",
+      "The unified API for UCI related data. View documentation at https://docs.icssc.club/docs/developer/anteaterapi and API reference at https://anteaterapi.com/reference.\n\nWhile all data from this API is derived from official UCI sources, we cannot guarantee its accuracy. However, we do take data accuracy very seriously, and we urge you to report any discrepancies at https://github.com/icssc/anteater-api/issues.",
     contact: { email: "icssc@uci.edu" },
   },
   externalDocs: {


### PR DESCRIPTION
Fix a typo in the description field of the OpenAPI spec.
"discrepancies" was spelled "discrepencies" (A replaced with E).
Thanks to @matt-franklin225 in https://github.com/icssc/anteater-api/pull/289#discussion_r2762573368.

my most useful API PR so far

# Test plan
- [ ] Open the auto-generated REST reference or hit `/openapi.json` and verify the typo is gone.
