### PR TITLE
perf: parallelize independent awaits in search service doSearch

### DIFF
--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -203,9 +203,13 @@ export class SearchService {
       ),
     );
 
+    const [courseMapping, instructorMapping] = await Promise.all([
+      this.courseMappingFromResults(results.course),
+      this.instructorMappingFromResults(results.instructor),
+    ]);
     const lookedUp = {
-      course: await this.courseMappingFromResults(results.course),
-      instructor: await this.instructorMappingFromResults(results.instructor),
+      course: courseMapping,
+      instructor: instructorMapping,
     };
 
     return {


### PR DESCRIPTION
# perf: parallelize independent DB lookups in search doSearch

## Summary
In `SearchService.doSearch` (the combined course+instructor search path), `courseMappingFromResults` and `instructorMappingFromResults` were awaited sequentially despite being independent database lookups against different tables. This change wraps them in `Promise.all` so they run concurrently, reducing wall-clock time for combined search queries.

## Review & Testing Checklist for Human
- [ ] Verify that `courseMappingFromResults` and `instructorMappingFromResults` are truly independent (no shared mutable state or ordering dependency). They call `batchGetCourses` and `batchGetInstructors` respectively — confirm these don't interact.
- [ ] Test the combined search endpoint (where `resultType` is unset / not "course" or "instructor") to verify results are unchanged. A quick manual hit against `/search?query=<something>` should suffice.

### Notes
- Only the combined search path in `doSearch` is affected. The type-specific `doSearchForCourses` and `doSearchForInstructors` methods are untouched.
- `Promise.all` fail-fast behavior is slightly different from sequential awaits: if the second call fails, the first call's in-flight work is not awaited. In practice this is immaterial since both would throw anyway.

Link to Devin run: https://app.devin.ai/sessions/d6a197f38d994663a439f83229c5b75f
Requested by: @sanskarm7