### PR TITLE
fix: gql cache milliseconds conversion

### DIFF
--- a/apps/api/src/graphql/plugins/yoga-kv-cache.ts
+++ b/apps/api/src/graphql/plugins/yoga-kv-cache.ts
@@ -13,7 +13,7 @@ export class YogaKVCache implements Cache {
   async set(id: string, data: ExecutionResult, _: unknown, ttl: number): Promise<void> {
     // convert milliseconds (Yoga) to seconds (Cloudflare) and enforce Cloudflare KV minimum of 60 seconds
     const expirationTtl = Math.max(Math.floor(ttl / 1000), 60);
-    await this.kv.put(id, JSON.stringify(data), { expirationTtl: expirationTtl });
+    await this.kv.put(id, JSON.stringify(data), { expirationTtl });
   }
 
   // This is a no-op because our API doesn't have mutations.


### PR DESCRIPTION
The recent AntAlmanac outage has been attributed to a GraphQL cache logic misstep in the codebase.

Upon inspection, the custom implementation of `YogaKVCache` doesn't observe the milliseconds -> seconds conversion that's needed to accurately enforce the cache `maxAge` of 5 mins (300 seconds).

What's happening is that Cloudflare is receiving 300,000 seconds as a value, and the cache is persisting for ~3.5 days.

This documentation supports this finding:

 - Cloudflare docs show that the [put](https://developers.cloudflare.com/kv/api/write-key-value-pairs/#put-method) operation for KV pairs operate using seconds
 - The [envelop plugin](https://github.com/graphql-hive/envelop/blob/main/packages/plugins/response-cache/src/plugin.ts#L367-L413) demonstrates conversion of `maxAge * 1000` (to milliseconds)
 - The cloudflare implemented version of set, located at `/@envelop/response-cache-cloudflare-kv/esm/set.js` [here](https://www.npmjs.com/package/@envelop/response-cache-cloudflare-kv?activeTab=code) utilizes:
      - `const ttlInSeconds = Math.max(Math.floor(ttl / 1000), 60); // KV TTL must be at least 60 seconds`

This bug was confirmed by the fact that the key for the original problematic AntAlmanac GraphQL key was associated with a new cache value ~3.5 days after initial set (not before).

By dividing values by 1000, we convert back to seconds, and set a minimum `ttl` of 60 seconds as per standard.
