### PR TITLE
hotfix: doChunkUpsert for course updates all except GEs

### DIFF
--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -76,7 +76,7 @@ const geCategoryToFlag: Record<(typeof geCategories)[number], keyof CourseGEUpda
   "GE-8": "isGE8",
 };
 
-const geColumns = Object.values(geCategoryToFlag);
+const geColumns = Object.values(geCategoryToFlag) as string[];
 
 export async function getDepts(db: ReturnType<typeof database>) {
   const response = await fetch("https://www.reg.uci.edu/perl/WebSoc").then((x) => x.text());
@@ -413,7 +413,7 @@ function meetingMapper(
 const allCourseCols = conflictUpdateSetAllCols(websocCourse);
 
 const courseUpdateSet = Object.fromEntries(
-  Object.entries(allCourseCols).filter(([key]) => !(geColumns as string[]).includes(key)),
+  Object.entries(allCourseCols).filter(([key]) => !geColumns.includes(key)),
 );
 
 const doChunkUpsert = async (


### PR DESCRIPTION
dante you may not like this..

added util function `conflictUpdateSetAllColsExcept` that mirrors the existing `conflictUpdateSetAllCols` function.

this new function also takes a set of columns that **must** exist and removes them from the update list provided by the first parameter.

simply replaced problematic function call in `doChunkUpsert` with new one, and fed it a list of GEs (there may be a list somewhere to import, i couldn't remember)