### PR TITLE
hotfix: restaurant today no data

### DIFF
--- a/apps/api/src/rest/routes/dining.ts
+++ b/apps/api/src/rest/routes/dining.ts
@@ -250,11 +250,11 @@ diningRouter.openapi(restaurantTodayRoute, async (c) => {
   const query = c.req.valid("query");
   const service = new DiningService(database(c.env.DB.connectionString));
 
-  const data = restaurantTodayResponseSchema.parse(await service.getRestaurantToday(query));
+  const data = await service.getRestaurantToday(query);
   if (!data) {
-    return c.json({ ok: false, message: "Restaurant not found" }, 404);
+    return c.json({ ok: false, message: "No data for this day" }, 404);
   }
-  return c.json({ ok: true, data: data }, 200);
+  return c.json({ ok: true, data: restaurantTodayResponseSchema.parse(data) }, 200);
 });
 
 export { diningRouter };


### PR DESCRIPTION
1. When there's no data, don't 500 with a Zod parse error.
2. The error message should indicate that there is no data, not that the restaurant ID is bad, because the restaurant ID enum schema already checks that the ID is valid.
