### PR TITLE
refactor(search): call toQuery once before branching (icssc#285)

### DIFF
--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -6,7 +6,7 @@ import type {
 } from "$schema";
 import type { z } from "@hono/zod-openapi";
 import type { database } from "@packages/db";
-import { and, asc, desc, inArray, or, sql } from "@packages/db/drizzle";
+import { type SQL, and, asc, desc, inArray, or, sql } from "@packages/db/drizzle";
 import { unionAll } from "@packages/db/drizzle-pg";
 import { course, instructor } from "@packages/db/schema";
 import { getFromMapOrThrow } from "@packages/stdlib";
@@ -101,8 +101,8 @@ export class SearchService {
 
   private async doSearchForCourses(
     input: SearchServiceInput,
+    query: SQL,
   ): Promise<z.infer<typeof searchResponseSchema>> {
-    const query = toQuery(input.query);
     const results = await this.db
       .select({
         id: course.id,
@@ -132,8 +132,8 @@ export class SearchService {
 
   private async doSearchForInstructors(
     input: SearchServiceInput,
+    query: SQL,
   ): Promise<z.infer<typeof searchResponseSchema>> {
-    const query = toQuery(input.query);
     const results = await this.db
       .select({
         id: instructor.ucinetid,
@@ -164,15 +164,16 @@ export class SearchService {
   }
 
   async doSearch(input: SearchServiceInput): Promise<z.infer<typeof searchResponseSchema>> {
+    const query = toQuery(input.query);
+
     if (input.resultType === "instructor") {
-      return this.doSearchForInstructors(input);
+      return this.doSearchForInstructors(input, query);
     }
 
     if (input.resultType === "course") {
-      return this.doSearchForCourses(input);
+      return this.doSearchForCourses(input, query);
     }
 
-    const query = toQuery(input.query);
     const results = await unionAll(
       this.db
         .select({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Moved the toQuery call before branching in doSearch to simplify the code. 

Previously, toQuery was called separately across three different code paths: in doSearchForCourses, doSearchForInstructors, and doSearch.

This change replaces those calls with a single toQuery call in doSearch. The result is stored in a constant and passed into doSearchForCourses and doSearchForInstructors, which were updated to accept the precomputed query.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#285

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change was made to simplify the code by making a single call to toQuery instead of three individual calls.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The changes were tested by confirming that local API calls matched the results prior to the change. 

Tested using the database dump provided in the Contributor Docs for setting up a local Anteater API environment.

## Screenshots (if appropriate):
N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
