### PR TITLE
fix (DegreeWorks): HotFix Degreeworks WithArray Filtering

### DIFF
--- a/apps/data-pipeline/degreeworks-scraper/src/components/AuditParser.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/AuditParser.ts
@@ -262,6 +262,8 @@ export class AuditParser {
   }
 
   filterThroughWithArray(classes: (typeof course.$inferSelect)[], withArray: WithClause[]) {
+    if (withArray.length === 0) return structuredClone(classes);
+
     // group AND clauses together: "A AND B OR C AND D" => [(A,B), (C,D)]
     const orGroups: WithClause[][] = [];
     let currentGroup: WithClause[] = [];


### PR DESCRIPTION
There was a bug in the filtering of withArrays from #322 where courses without a withArray were filtered out when they should have all been left in.