### PR TITLE
fix: study room dependent on session tz

### DIFF
--- a/apps/api/src/services/study-rooms.ts
+++ b/apps/api/src/services/study-rooms.ts
@@ -25,11 +25,11 @@ export class StudyRoomsService {
           sql`ARRAY_REMOVE(COALESCE(ARRAY_AGG(CASE WHEN ${studyRoomSlot.studyRoomId} IS NULL THEN NULL
             ELSE JSONB_BUILD_OBJECT(
               'studyRoomId', ${studyRoomSlot.studyRoomId},
-              'start', TO_JSON(${studyRoomSlot.start} AT TIME ZONE 'America/Los_Angeles'),
-              'end', TO_JSON(${studyRoomSlot.end} AT TIME ZONE 'America/Los_Angeles'),
+              'start', TO_CHAR((${studyRoomSlot.start} AT TIME ZONE 'America/Los_Angeles') AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"+00:00"'),
+              'end', TO_CHAR((${studyRoomSlot.end} AT TIME ZONE 'America/Los_Angeles') AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"+00:00"'),
               'url', CASE
                 WHEN ${studyRoom.url} IS NOT NULL THEN ${studyRoom.url}
-                ELSE 'https://spaces.lib.uci.edu/space/' || ${studyRoom.id} || '?date=' || TO_CHAR(${studyRoomSlot.start}::timestamptz at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') || '#submit_times'
+                ELSE 'https://spaces.lib.uci.edu/space/' || ${studyRoom.id} || '?date=' || TO_CHAR((${studyRoomSlot.start} AT TIME ZONE 'America/Los_Angeles') AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') || '#submit_times'
               END,
               'isAvailable', ${studyRoomSlot.isAvailable}
             )
@@ -47,8 +47,6 @@ export class StudyRoomsService {
   }
 
   async getStudyRooms(input: StudyRoomsServiceInput) {
-    await this.db.execute(sql`SET TIME ZONE 'America/Los_Angeles';`);
-
     const conditions = [];
     if (input.location) conditions.push(eq(studyRoom.location, input.location));
     if (input.capacityMin) conditions.push(gte(studyRoom.capacity, input.capacityMin));
@@ -59,10 +57,7 @@ export class StudyRoomsService {
       conditions.push(
         or(
           ...input.dates.map((date) =>
-            eq(
-              sql`(${studyRoomSlot.start} AT TIME ZONE 'America/Los_Angeles')::DATE`,
-              sql`${date.toISOString()}::DATE`,
-            ),
+            eq(sql`${studyRoomSlot.start}::DATE`, sql`${date.toISOString()}::DATE`),
           ),
         ),
       );
@@ -73,12 +68,12 @@ export class StudyRoomsService {
             and(
               // 1. the end time must be later than the lower bound of the user-specified range; otherwise, the slot is certainly too early
               gt(
-                sql`(${studyRoomSlot.end} AT TIME ZONE 'America/Los_Angeles')::TIME`,
+                sql`${studyRoomSlot.end}::TIME`,
                 sql`(${lower.getUTCHours().toString().padStart(2, "0")} || ${lower.getUTCMinutes().toString().padStart(2, "0")})::TIME`,
               ),
               // 2. the start time must be earlier than the upper bound of the user-specified range; otherwise, the slot is certainly too late
               lt(
-                sql`(${studyRoomSlot.start} AT TIME ZONE 'America/Los_Angeles')::TIME`,
+                sql`${studyRoomSlot.start}::TIME`,
                 sql`(${upper.getUTCHours().toString().padStart(2, "0")} || ${upper.getUTCMinutes().toString().padStart(2, "0")})::TIME`,
               ),
             ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
currently depends on session tz

Also, locked response to UTC, was helpful for testing but technically not needed. (lines 28-29)
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/icssc/anteater-api/issues/360
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context


<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
with old vs new sql query
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
