### PR TITLE
feat(websoc-scraper): added observability during GE scrape

### DIFF
--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -732,6 +732,24 @@ type CourseGEUpdate = {
   isGE8?: boolean;
 };
 
+async function getGECountsFromDB(db: ReturnType<typeof database>, term: Term) {
+  return db
+    .select({
+      "GE-1A": sql<number>`count(*) filter (where ${websocCourse.isGE1A})`,
+      "GE-1B": sql<number>`count(*) filter (where ${websocCourse.isGE1B})`,
+      "GE-2": sql<number>`count(*) filter (where ${websocCourse.isGE2})`,
+      "GE-3": sql<number>`count(*) filter (where ${websocCourse.isGE3})`,
+      "GE-4": sql<number>`count(*) filter (where ${websocCourse.isGE4})`,
+      "GE-5A": sql<number>`count(*) filter (where ${websocCourse.isGE5A})`,
+      "GE-5B": sql<number>`count(*) filter (where ${websocCourse.isGE5B})`,
+      "GE-6": sql<number>`count(*) filter (where ${websocCourse.isGE6})`,
+      "GE-7": sql<number>`count(*) filter (where ${websocCourse.isGE7})`,
+      "GE-8": sql<number>`count(*) filter (where ${websocCourse.isGE8})`,
+    })
+    .from(websocCourse)
+    .where(and(eq(websocCourse.year, term.year), eq(websocCourse.quarter, term.quarter)));
+}
+
 async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
   const updates = new Map<string, CourseGEUpdate>();
   const outcomes: Record<string, "success" | "empty" | "error"> = {};

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -757,7 +757,9 @@ async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
   const scrapedCounts: Record<string, number> = {};
 
   const before = await getGECountsFromDB(db, term);
-  console.log(`[GE scrape] DB counts BEFORE for ${termToName(term)}:`, before);
+  console.log(
+    JSON.stringify({ event: "ge_scrape_db_before", term: termToName(term), counts: before }),
+  );
 
   for (const ge of geCategories) {
     console.log(`Scraping ${ge}`);
@@ -830,16 +832,16 @@ async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
 
   const after = await getGECountsFromDB(db, term);
 
-  const summary = geCategories.map((ge) => {
-    const stored = after?.[ge] ?? 0;
-    const scraped = scrapedCounts[ge] ?? 0;
-    const outcome = outcomes[ge];
-    const storedLabel = outcome === "error" ? "preserved" : "stored";
-    const diff = outcome === "success" ? scraped - stored : 0;
-    const diffNote = diff > 0 ? `  (${diff} unmatched)` : "";
-    return `  ${ge}: scraped=${scraped}  ${storedLabel}=${stored}  outcome=${outcome}${diffNote}`;
-  });
-  console.log(`[GE scrape] per-category summary for ${termToName(term)}:\n${summary.join("\n")}`);
+  const categories = Object.fromEntries(
+    geCategories.map((ge) => {
+      const scraped = scrapedCounts[ge] ?? 0;
+      const dbCount = Number(after?.[ge] ?? 0);
+      const outcome = outcomes[ge];
+      const notInDb = outcome === "success" ? Math.max(scraped - dbCount, 0) : 0;
+      return [ge, { scraped, dbCount, outcome, notInDb }];
+    }),
+  );
+  console.log(JSON.stringify({ event: "ge_scrape_summary", term: termToName(term), categories }));
 }
 
 export async function scrapeTerm(db: ReturnType<typeof database>, term: Term) {

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -754,6 +754,7 @@ async function getGECountsFromDB(db: ReturnType<typeof database>, term: Term) {
 async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
   const updates = new Map<string, CourseGEUpdate>();
   const outcomes: Record<string, "success" | "empty" | "error"> = {};
+  const scrapedCounts: Record<string, number> = {};
 
   const before = await getGECountsFromDB(db, term);
   console.log(`[GE scrape] DB counts BEFORE for ${termToName(term)}:`, before);
@@ -781,6 +782,7 @@ async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
       outcomes[ge] = "error";
       console.error(`[${ge}] failed to scrape GE data for term ${termToName(term)}`, e);
     }
+    scrapedCounts[ge] = courses.length;
 
     for (const course of courses) {
       const update = updates.get(course);
@@ -792,7 +794,7 @@ async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
     }
     await sleep(1000);
   }
-  console.log(`[GE scrape] outcomes for ${termToName(term)}:`, outcomes);
+
   await db.transaction(async (tx) => {
     // reset all flags to false for categories that didn't error
     const resetSet: Partial<CourseGEUpdate> = {};
@@ -827,7 +829,17 @@ async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
   console.log(`Updated GE data for ${updates.size} courses`);
 
   const after = await getGECountsFromDB(db, term);
-  console.log(`[GE scrape] DB counts AFTER for ${termToName(term)}:`, after);
+
+  const summary = geCategories.map((ge) => {
+    const stored = after?.[ge] ?? 0;
+    const scraped = scrapedCounts[ge] ?? 0;
+    const outcome = outcomes[ge];
+    const storedLabel = outcome === "error" ? "preserved" : "stored";
+    const diff = outcome === "success" ? scraped - stored : 0;
+    const diffNote = diff > 0 ? `  (${diff} unmatched)` : "";
+    return `  ${ge}: scraped=${scraped}  ${storedLabel}=${stored}  outcome=${outcome}${diffNote}`;
+  });
+  console.log(`[GE scrape] per-category summary for ${termToName(term)}:\n${summary.join("\n")}`);
 }
 
 export async function scrapeTerm(db: ReturnType<typeof database>, term: Term) {

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -794,6 +794,20 @@ async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
   }
   console.log(`[GE scrape] outcomes for ${termToName(term)}:`, outcomes);
   await db.transaction(async (tx) => {
+    // reset all flags to false for categories that didn't error
+    const resetSet: Partial<CourseGEUpdate> = {};
+    for (const ge of geCategories) {
+      if (outcomes[ge] !== "error") {
+        resetSet[geCategoryToFlag[ge]] = false;
+      }
+    }
+    if (Object.keys(resetSet).length > 0) {
+      await tx
+        .update(websocCourse)
+        .set(resetSet)
+        .where(and(eq(websocCourse.year, term.year), eq(websocCourse.quarter, term.quarter)));
+    }
+
     for (const [course, update] of updates) {
       const [deptCode, courseNumber, courseTitle] = course.split(",", 3);
       await tx

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -747,7 +747,8 @@ async function getGECountsFromDB(db: ReturnType<typeof database>, term: Term) {
       "GE-8": sql<number>`count(*) filter (where ${websocCourse.isGE8})`,
     })
     .from(websocCourse)
-    .where(and(eq(websocCourse.year, term.year), eq(websocCourse.quarter, term.quarter)));
+    .where(and(eq(websocCourse.year, term.year), eq(websocCourse.quarter, term.quarter)))
+    .then((rows) => rows[0]);
 }
 
 async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -734,6 +734,7 @@ type CourseGEUpdate = {
 
 async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
   const updates = new Map<string, CourseGEUpdate>();
+  const outcomes: Record<string, "success" | "empty" | "error"> = {};
   for (const ge of geCategories) {
     console.log(`Scraping GE ${ge}`);
     let courses: string[] = [];
@@ -747,13 +748,15 @@ async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
         ),
       );
       if (courses.length === 0) {
+        outcomes[ge] = "empty";
         console.warn(`[GE ${ge}] empty response - 0 courses returned`);
       } else {
+        outcomes[ge] = "success";
         console.log(`[GE ${ge}] found ${courses.length} courses`);
       }
     } catch (e) {
+      outcomes[ge] = "error";
       console.error(`[GE ${ge}] failed to scrape GE data for term ${termToName(term)}`, e);
-      continue;
     }
 
     for (const course of courses) {
@@ -766,6 +769,7 @@ async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
     }
     await sleep(1000);
   }
+  console.log(`[GE scrape] outcomes for ${termToName(term)}:`, outcomes);
   await db.transaction(async (tx) => {
     for (const [course, update] of updates) {
       const [deptCode, courseNumber, courseTitle] = course.split(",", 3);

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -736,14 +736,26 @@ async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
   const updates = new Map<string, CourseGEUpdate>();
   for (const ge of geCategories) {
     console.log(`Scraping GE ${ge}`);
-    const resp = await request(term, { ge, cancelledCourses: "Include" }).then(normalizeResponse);
-    const courses = resp.schools.flatMap((school) =>
-      school.departments.flatMap((dept) =>
-        dept.courses.map(
-          (course) => `${course.deptCode},${course.courseNumber},${course.courseTitle}`,
+    let courses: string[] = [];
+    try {
+      const resp = await request(term, { ge, cancelledCourses: "Include" }).then(normalizeResponse);
+      courses = resp.schools.flatMap((school) =>
+        school.departments.flatMap((dept) =>
+          dept.courses.map(
+            (course) => `${course.deptCode},${course.courseNumber},${course.courseTitle}`,
+          ),
         ),
-      ),
-    );
+      );
+      if (courses.length === 0) {
+        console.warn(`[GE ${ge}] empty response - 0 courses returned`);
+      } else {
+        console.log(`[GE ${ge}] found ${courses.length} courses`);
+      }
+    } catch (e) {
+      console.error(`[GE ${ge}] failed to scrape GE data for term ${termToName(term)}`, e);
+      continue;
+    }
+
     for (const course of courses) {
       const update = updates.get(course);
       if (update) {

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -754,6 +754,10 @@ async function getGECountsFromDB(db: ReturnType<typeof database>, term: Term) {
 async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
   const updates = new Map<string, CourseGEUpdate>();
   const outcomes: Record<string, "success" | "empty" | "error"> = {};
+
+  const before = await getGECountsFromDB(db, term);
+  console.log(`[GE scrape] DB counts BEFORE for ${termToName(term)}:`, before);
+
   for (const ge of geCategories) {
     console.log(`Scraping GE ${ge}`);
     let courses: string[] = [];
@@ -807,6 +811,9 @@ async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
     }
   });
   console.log(`Updated GE data for ${updates.size} courses`);
+
+  const after = await getGECountsFromDB(db, term);
+  console.log(`[GE scrape] DB counts AFTER for ${termToName(term)}:`, after);
 }
 
 export async function scrapeTerm(db: ReturnType<typeof database>, term: Term) {

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -735,16 +735,16 @@ type CourseGEUpdate = {
 async function getGECountsFromDB(db: ReturnType<typeof database>, term: Term) {
   return db
     .select({
-      "GE-1A": sql<number>`count(*) filter (where ${websocCourse.isGE1A})`,
-      "GE-1B": sql<number>`count(*) filter (where ${websocCourse.isGE1B})`,
-      "GE-2": sql<number>`count(*) filter (where ${websocCourse.isGE2})`,
-      "GE-3": sql<number>`count(*) filter (where ${websocCourse.isGE3})`,
-      "GE-4": sql<number>`count(*) filter (where ${websocCourse.isGE4})`,
-      "GE-5A": sql<number>`count(*) filter (where ${websocCourse.isGE5A})`,
-      "GE-5B": sql<number>`count(*) filter (where ${websocCourse.isGE5B})`,
-      "GE-6": sql<number>`count(*) filter (where ${websocCourse.isGE6})`,
-      "GE-7": sql<number>`count(*) filter (where ${websocCourse.isGE7})`,
-      "GE-8": sql<number>`count(*) filter (where ${websocCourse.isGE8})`,
+      "GE-1A": sql<number>`count(*)::int filter (where ${websocCourse.isGE1A})`,
+      "GE-1B": sql<number>`count(*)::int filter (where ${websocCourse.isGE1B})`,
+      "GE-2": sql<number>`count(*)::int filter (where ${websocCourse.isGE2})`,
+      "GE-3": sql<number>`count(*)::int filter (where ${websocCourse.isGE3})`,
+      "GE-4": sql<number>`count(*)::int filter (where ${websocCourse.isGE4})`,
+      "GE-5A": sql<number>`count(*)::int filter (where ${websocCourse.isGE5A})`,
+      "GE-5B": sql<number>`count(*)::int filter (where ${websocCourse.isGE5B})`,
+      "GE-6": sql<number>`count(*)::int filter (where ${websocCourse.isGE6})`,
+      "GE-7": sql<number>`count(*)::int filter (where ${websocCourse.isGE7})`,
+      "GE-8": sql<number>`count(*)::int filter (where ${websocCourse.isGE8})`,
     })
     .from(websocCourse)
     .where(and(eq(websocCourse.year, term.year), eq(websocCourse.quarter, term.quarter)))

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -760,7 +760,7 @@ async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
   console.log(`[GE scrape] DB counts BEFORE for ${termToName(term)}:`, before);
 
   for (const ge of geCategories) {
-    console.log(`Scraping GE ${ge}`);
+    console.log(`Scraping ${ge}`);
     let courses: string[] = [];
     try {
       const resp = await request(term, { ge, cancelledCourses: "Include" }).then(normalizeResponse);

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -749,14 +749,14 @@ async function scrapeGEsForTerm(db: ReturnType<typeof database>, term: Term) {
       );
       if (courses.length === 0) {
         outcomes[ge] = "empty";
-        console.warn(`[GE ${ge}] empty response - 0 courses returned`);
+        console.warn(`[${ge}] empty response - 0 courses returned`);
       } else {
         outcomes[ge] = "success";
-        console.log(`[GE ${ge}] found ${courses.length} courses`);
+        console.log(`[${ge}] found ${courses.length} courses`);
       }
     } catch (e) {
       outcomes[ge] = "error";
-      console.error(`[GE ${ge}] failed to scrape GE data for term ${termToName(term)}`, e);
+      console.error(`[${ge}] failed to scrape GE data for term ${termToName(term)}`, e);
     }
 
     for (const course of courses) {
@@ -817,7 +817,12 @@ export async function scrapeTerm(db: ReturnType<typeof database>, term: Term) {
     await ingestChunk(db, term, lastKnownCode + 1, LAST_SECTION_CODE);
   }
 
-  await scrapeGEsForTerm(db, term);
+  try {
+    await scrapeGEsForTerm(db, term);
+  } catch (e) {
+    console.error(`[scrapeTerm] scrapeGEsForTerm failed for term ${termToName(term)}`, e);
+    throw e;
+  }
   const values = { name, lastScraped: new Date() };
   await db
     .insert(websocMeta)


### PR DESCRIPTION
## Description

Adds observability logging to the Websoc scraping pipeline for the GE scrape per term, focusing on highlighting the scrape counts for each GE category within each term. Also adds before and after logging of stored GE counts to allow observation regarding any changes from scrapes over time – especially during the buggy hours. 

This PR also fixed a correctness bug during GE scraping where, previously, GE flags on Websoc courses would never be reset to false if a course lost its GE designation (category specific) between scrapes. This change means stale true flags will not persist indefinitely, even if the likelihood of this is low.

## Related Issue

#302 

## Motivation and Context

We previously experienced issues with the Websoc course table seemingly dropping GE data. These observability changes are an initial step towards figuring out (as much as we can) why GE course data is occasionally dropped. 

## How Has This Been Tested?

Ran Websoc scraper locally and verified GE flag reset logic against the existing DB transactions.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.