### PR TITLE
fix(library-traffic): reduce library traffic scrape load

### DIFF
--- a/apps/data-pipeline/library-traffic-scraper/src/lib.ts
+++ b/apps/data-pipeline/library-traffic-scraper/src/lib.ts
@@ -206,7 +206,7 @@ export async function doScrape(db: ReturnType<typeof database>) {
   console.log("Starting library traffic scrape.");
 
   const cutoff = new Date();
-  cutoff.setMonth(cutoff.getMonth() - 13);
+  cutoff.setMonth(cutoff.getMonth() - 15);
   await db.delete(libraryTrafficHistory).where(lt(libraryTrafficHistory.timestamp, cutoff));
 
   const locationMeta = await collectLocationMeta();

--- a/apps/data-pipeline/library-traffic-scraper/src/lib.ts
+++ b/apps/data-pipeline/library-traffic-scraper/src/lib.ts
@@ -1,4 +1,5 @@
 import type { database } from "@packages/db";
+import { lt } from "@packages/db/drizzle";
 import { libraryTraffic, libraryTrafficHistory } from "@packages/db/schema";
 import { conflictUpdateSetAllCols } from "@packages/db/utils";
 import { load } from "cheerio";
@@ -203,6 +204,11 @@ const libraryCodeMap = {
 
 export async function doScrape(db: ReturnType<typeof database>) {
   console.log("Starting library traffic scrape.");
+
+  const cutoff = new Date();
+  cutoff.setMonth(cutoff.getMonth() - 13);
+  await db.delete(libraryTrafficHistory).where(lt(libraryTrafficHistory.timestamp, cutoff));
+
   const locationMeta = await collectLocationMeta();
 
   const currentTime = new Date();

--- a/apps/data-pipeline/library-traffic-scraper/src/lib.ts
+++ b/apps/data-pipeline/library-traffic-scraper/src/lib.ts
@@ -205,10 +205,6 @@ const libraryCodeMap = {
 export async function doScrape(db: ReturnType<typeof database>) {
   console.log("Starting library traffic scrape.");
 
-  const cutoff = new Date();
-  cutoff.setMonth(cutoff.getMonth() - 15);
-  await db.delete(libraryTrafficHistory).where(lt(libraryTrafficHistory.timestamp, cutoff));
-
   const locationMeta = await collectLocationMeta();
 
   const currentTime = new Date();
@@ -267,6 +263,10 @@ export async function doScrape(db: ReturnType<typeof database>) {
       },
     ]);
   }
+
+  const cutoff = new Date();
+  cutoff.setMonth(cutoff.getMonth() - 15);
+  await db.delete(libraryTrafficHistory).where(lt(libraryTrafficHistory.timestamp, cutoff));
 
   console.log("Library traffic scrape complete.");
 }

--- a/apps/data-pipeline/library-traffic-scraper/wrangler.toml
+++ b/apps/data-pipeline/library-traffic-scraper/wrangler.toml
@@ -6,7 +6,7 @@ workers_dev = false
 minify = true
 
 [triggers]
-crons = ["*/15 * * * *"]
+crons = ["*/30 * * * *"]
 
 [observability]
 enabled = true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Reduces library traffic scraper load by halving the scrape frequency and pruning stale history records.

- Cron schedule changed from `*/15 * * * *` to `*/30 * * * *` — scraper now runs every 30 minutes instead of 15
- On each scrape run, history records older than 13 months are deleted before new data is inserted — this keeps one full year of data plus a one-quarter buffer for year-over-year comparisons (e.g. Fall 2025 finals vs Fall 2026 finals) without unbounded table growth

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#268 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
