### PR TITLE
fix(search): course search query adjustment fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ node_modules
 # IDEs
 .idea/
 .vscode/
+*.session.sql
 
 # wrangler
 .wrangler/

--- a/apps/api/src/middleware/access-controller.ts
+++ b/apps/api/src/middleware/access-controller.ts
@@ -1,5 +1,6 @@
-import type { AccessControlledResource } from "@packages/key-types";
+import type { AccessControlledResource, KeyData } from "@packages/key-types";
 import { createMiddleware } from "hono/factory";
+import { HTTPException } from "hono/http-exception";
 
 /**
  * Middleware for restricting access to certain routes.
@@ -9,7 +10,6 @@ import { createMiddleware } from "hono/factory";
  */
 export const accessController = (resource: AccessControlledResource) =>
   createMiddleware<{ Bindings: Env }>(async (c, next) => {
-    /*
     const header = c.req.header("authorization");
     if (!header) {
       throw new HTTPException(401, { message: "An API key is required to access this resource" });
@@ -22,6 +22,5 @@ export const accessController = (resource: AccessControlledResource) =>
         message: "The specified API key is not permitted to access this resource",
       });
     }
-      */
     await next();
   });

--- a/apps/api/src/middleware/access-controller.ts
+++ b/apps/api/src/middleware/access-controller.ts
@@ -1,6 +1,5 @@
-import type { AccessControlledResource, KeyData } from "@packages/key-types";
+import type { AccessControlledResource } from "@packages/key-types";
 import { createMiddleware } from "hono/factory";
-import { HTTPException } from "hono/http-exception";
 
 /**
  * Middleware for restricting access to certain routes.
@@ -10,6 +9,7 @@ import { HTTPException } from "hono/http-exception";
  */
 export const accessController = (resource: AccessControlledResource) =>
   createMiddleware<{ Bindings: Env }>(async (c, next) => {
+    /*
     const header = c.req.header("authorization");
     if (!header) {
       throw new HTTPException(401, { message: "An API key is required to access this resource" });
@@ -22,5 +22,6 @@ export const accessController = (resource: AccessControlledResource) =>
         message: "The specified API key is not permitted to access this resource",
       });
     }
+      */
     await next();
   });

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -42,7 +42,7 @@ function toQuery(query: string, resultType?: "instructor" | "course") {
   if (resultType === "course")
     for (const code in DEPT_TO_ALIAS)
       normalizedQuery = normalizedQuery.replaceAll(
-        new RegExp(`(^|s)${DEPT_TO_ALIAS[code as DeptCode].toLowerCase()}`, "gi"),
+        new RegExp(`(^|\\s)${DEPT_TO_ALIAS[code as DeptCode].toLowerCase()}`, "gi"),
         `${code.toLowerCase()} `,
       );
 

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -42,7 +42,7 @@ function toQuery(query: string, resultType?: "instructor" | "course") {
   if (resultType && resultType === "course")
     for (const code in DEPT_TO_ALIAS)
       normalizedQuery = normalizedQuery.replaceAll(
-        `${DEPT_TO_ALIAS[code as DeptCode].toLowerCase()} `,
+        new RegExp(`(^|s)${DEPT_TO_ALIAS[code as DeptCode].toLowerCase()}`, "gi"),
         `${code.toLowerCase()} `,
       );
 

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -31,14 +31,17 @@ const INSTRUCTORS_WEIGHTS = sql`(
   SETWEIGHT(TO_TSVECTOR('english', COALESCE(${instructor.title}, '')), 'B')
   )`;
 
-function toQuery(query: string) {
-  const normalizedQuery = query
+function toQuery(query: string, inputType?: "instructor" | "course") {
+  let normalizedQuery = query
     .replaceAll(/ {2,}/g, " ")
     .replaceAll(/-/g, "\\-")
-    .replaceAll("ics", "i&csci")
     .split(" ")
     .map((x) => x.replace(/^\\-/, "-"))
     .join(" ");
+
+  if (inputType && inputType === "course")
+    normalizedQuery = normalizedQuery.replaceAll("ics", "i&csci");
+
   const tsQuery = sql`WEBSEARCH_TO_TSQUERY('english', ${normalizedQuery})`;
   return sql`CASE WHEN NUMNODE(${tsQuery}) > 0 THEN TO_TSQUERY('english', ${tsQuery}::TEXT || ':*') ELSE '' END`;
 }
@@ -156,7 +159,7 @@ export class SearchService {
   }
 
   async doSearch(input: SearchServiceInput): Promise<z.infer<typeof searchResponseSchema>> {
-    const query = toQuery(transformQuery(input.query));
+    const query = toQuery(input.query);
 
     if (input.resultType === "instructor") {
       return this.doSearchForInstructors(input, query);

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -31,19 +31,11 @@ const INSTRUCTORS_WEIGHTS = sql`(
   SETWEIGHT(TO_TSVECTOR('english', COALESCE(${instructor.title}, '')), 'B')
   )`;
 
-function splitAtLastNumber(s: string): string {
-  const i = s
-    .matchAll(/\d+/g)
-    .map((x) => x.index)
-    .toArray()
-    .slice(-1)[0];
-  return i === undefined ? s : `${s.slice(0, i)} ${s.slice(i)}`;
-}
-
 function toQuery(query: string) {
-  const normalizedQuery = splitAtLastNumber(query)
+  const normalizedQuery = query
     .replaceAll(/ {2,}/g, " ")
     .replaceAll(/-/g, "\\-")
+    .replaceAll("ics", "i&csci")
     .split(" ")
     .map((x) => x.replace(/^\\-/, "-"))
     .join(" ");
@@ -164,7 +156,7 @@ export class SearchService {
   }
 
   async doSearch(input: SearchServiceInput): Promise<z.infer<typeof searchResponseSchema>> {
-    const query = toQuery(input.query);
+    const query = toQuery(transformQuery(input.query));
 
     if (input.resultType === "instructor") {
       return this.doSearchForInstructors(input, query);

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -31,7 +31,7 @@ const INSTRUCTORS_WEIGHTS = sql`(
   SETWEIGHT(TO_TSVECTOR('english', COALESCE(${instructor.title}, '')), 'B')
   )`;
 
-function toQuery(query: string, inputType?: "instructor" | "course") {
+function toQuery(query: string, resultType?: "instructor" | "course") {
   let normalizedQuery = query
     .replaceAll(/ {2,}/g, " ")
     .replaceAll(/-/g, "\\-")
@@ -39,7 +39,7 @@ function toQuery(query: string, inputType?: "instructor" | "course") {
     .map((x) => x.replace(/^\\-/, "-"))
     .join(" ");
 
-  if (inputType && inputType === "course")
+  if (resultType && resultType === "course")
     normalizedQuery = normalizedQuery.replaceAll("ics", "i&csci");
 
   const tsQuery = sql`WEBSEARCH_TO_TSQUERY('english', ${normalizedQuery})`;
@@ -159,7 +159,7 @@ export class SearchService {
   }
 
   async doSearch(input: SearchServiceInput): Promise<z.infer<typeof searchResponseSchema>> {
-    const query = toQuery(input.query);
+    const query = toQuery(input.query, input.resultType);
 
     if (input.resultType === "instructor") {
       return this.doSearchForInstructors(input, query);

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -39,7 +39,7 @@ function toQuery(query: string, resultType?: "instructor" | "course") {
     .map((x) => x.replace(/^\\-/, "-"))
     .join(" ");
 
-  if (resultType && resultType === "course")
+  if (resultType === "course")
     for (const code in DEPT_TO_ALIAS)
       normalizedQuery = normalizedQuery.replaceAll(
         new RegExp(`(^|s)${DEPT_TO_ALIAS[code as DeptCode].toLowerCase()}`, "gi"),

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -42,7 +42,7 @@ function toQuery(query: string, resultType?: "instructor" | "course") {
   if (resultType === "course")
     for (const code in DEPT_TO_ALIAS)
       normalizedQuery = normalizedQuery.replaceAll(
-        new RegExp(`(^|\\s)${DEPT_TO_ALIAS[code as DeptCode].toLowerCase()}`, "gi"),
+        new RegExp(`(^|\\s)${DEPT_TO_ALIAS[code as DeptCode].toLocaleLowerCase()}(?!i)`, "gi"),
         `${code.toLowerCase()} `,
       );
 

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -173,15 +173,19 @@ export class SearchService {
       return this.doSearchForCourses(input, query);
     }
 
+    const courseAdjustedQuery = toQuery(input.query, "course");
+
     const results = await unionAll(
       this.db
         .select({
           type: sql<SearchResultType>`'course'`,
           id: course.id,
-          rank: sql`TS_RANK(${COURSES_WEIGHTS}, ${query})`.mapWith(Number),
+          rank: sql`TS_RANK(${COURSES_WEIGHTS}, ${courseAdjustedQuery})`.mapWith(Number),
         })
         .from(course)
-        .where(and(this.buildCourseConditions(input), sql`${COURSES_WEIGHTS} @@ ${query}`)),
+        .where(
+          and(this.buildCourseConditions(input), sql`${COURSES_WEIGHTS} @@ ${courseAdjustedQuery}`),
+        ),
       this.db
         .select({
           type: sql<SearchResultType>`'instructor'`,

--- a/apps/api/src/services/search.ts
+++ b/apps/api/src/services/search.ts
@@ -3,7 +3,7 @@ import type { database } from "@packages/db";
 import { and, asc, desc, inArray, or, type SQL, sql } from "@packages/db/drizzle";
 import { unionAll } from "@packages/db/drizzle-pg";
 import { course, instructor } from "@packages/db/schema";
-import { getFromMapOrThrow } from "@packages/stdlib";
+import { DEPT_TO_ALIAS, type DeptCode, getFromMapOrThrow } from "@packages/stdlib";
 import type {
   courseSchema,
   instructorSchema,
@@ -40,7 +40,11 @@ function toQuery(query: string, resultType?: "instructor" | "course") {
     .join(" ");
 
   if (resultType && resultType === "course")
-    normalizedQuery = normalizedQuery.replaceAll("ics", "i&csci");
+    for (const code in DEPT_TO_ALIAS)
+      normalizedQuery = normalizedQuery.replaceAll(
+        `${DEPT_TO_ALIAS[code as DeptCode].toLowerCase()} `,
+        `${code.toLowerCase()} `,
+      );
 
   const tsQuery = sql`WEBSEARCH_TO_TSQUERY('english', ${normalizedQuery})`;
   return sql`CASE WHEN NUMNODE(${tsQuery}) > 0 THEN TO_TSQUERY('english', ${tsQuery}::TEXT || ':*') ELSE '' END`;

--- a/apps/data-pipeline/course-scraper/src/index.ts
+++ b/apps/data-pipeline/course-scraper/src/index.ts
@@ -12,7 +12,7 @@ import {
   websocDepartment,
   websocSchool,
 } from "@packages/db/schema";
-import { orNull, sleep } from "@packages/stdlib";
+import { DEPT_TO_ALIAS, type DeptCode, orNull, sleep } from "@packages/stdlib";
 import { load } from "cheerio";
 import fetch from "cross-fetch";
 import type { Element as DomElement } from "domhandler";
@@ -62,18 +62,6 @@ const unitFormatter = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 2,
   minimumFractionDigits: 2,
 });
-
-const DEPT_TO_ALIAS = {
-  COMPSCI: "CS",
-  EARTHSS: "ESS",
-  "I&C SCI": "ICS",
-  IN4MATX: "INF",
-  ENGRMAE: "MAE",
-  WRITING: "WR",
-} as const;
-
-type DeptAliasMap = typeof DEPT_TO_ALIAS;
-type DeptCode = keyof DeptAliasMap;
 
 const getDepartmentAlias = (dept: string) => orNull(DEPT_TO_ALIAS[dept as DeptCode]);
 

--- a/packages/stdlib/src/dept-utils.ts
+++ b/packages/stdlib/src/dept-utils.ts
@@ -1,0 +1,11 @@
+export const DEPT_TO_ALIAS = {
+  COMPSCI: "CS",
+  EARTHSS: "ESS",
+  "I&C SCI": "ICS",
+  IN4MATX: "INF",
+  ENGRMAE: "MAE",
+  WRITING: "WR",
+} as const;
+
+export type DeptAliasMap = typeof DEPT_TO_ALIAS;
+export type DeptCode = keyof DeptAliasMap;

--- a/packages/stdlib/src/index.ts
+++ b/packages/stdlib/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./day-utils";
+export * from "./dept-utils";
 export * from "./int-utils";
 export * from "./map-utils";
 export * from "./null-utils";


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

The primary change here is that we no longer split the letter from the course code as we were previously, **i.e.**
`ICS H32` -> `ICS H 32` this seemed to be disrupting Postgres FTS as after this step was removed searches like H197 and H32 seemed to function perfectly fine. Perhaps there is some tribal knowledge that has been lost related to this but search seems to perform extremely similarly with the obvious exception that special courses like H32 and H197 pop up with more ergonomic query patterns.

I also added a small replacement on course searches that converts ICS to I&CSCI since most people colloquially refer to ICS courses as ICS ##, this could also be applied to other departments if there are other relevant examples.

I tested this with a local environment of AntAlmanac Planner.

## Related Issue
#186 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
