### PR TITLE
fix(websoc): Websoc Instructor Intersection Groups By Section

### DIFF
--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -507,14 +507,17 @@ const doChunkUpsert = async (db: ReturnType<typeof database>, term: Term, resp: 
       .flatMap((school) =>
         school.departments.flatMap((dept) =>
           dept.courses.flatMap((course) =>
-            course.sections.flatMap((section) =>
-              Array.from(
-                intersectAll(
-                  new Set(course.sections[0].instructors),
-                  ...course.sections.slice(1).map((section) => new Set(section.instructors)),
-                ),
-              ).map((instructor) => [section.sectionCode, instructor]),
-            ),
+            course.sections.flatMap((section) => {
+              const letterMatch = section.sectionNum.match(/[a-z]+/i);
+              const letter = letterMatch ? letterMatch[0] : "";
+              const groupedSections = course.sections
+                .filter((section) => section.sectionNum.match(letter))
+                .map((section) => new Set(section.instructors));
+
+              return Array.from(intersectAll(groupedSections[0], ...groupedSections.slice(1))).map(
+                (instructor) => [section.sectionCode, instructor],
+              );
+            }),
           ),
         ),
       )
@@ -925,7 +928,8 @@ export async function doScrape(db: ReturnType<typeof database>) {
   const term = termsInDatabase[0];
   if (term?.name) {
     try {
-      await scrapeTerm(db, nameToTerm(term.name));
+      //await scrapeTerm(db, nameToTerm(term.name));
+      await scrapeTerm(db, nameToTerm("2026 Fall"));
     } catch (e) {
       console.error(e);
     }

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -508,15 +508,25 @@ const doChunkUpsert = async (db: ReturnType<typeof database>, term: Term, resp: 
         school.departments.flatMap((dept) =>
           dept.courses.flatMap((course) =>
             course.sections.flatMap((section) => {
+              // Try to prevent TAs from being included
+              // Lec sections (usually) only contain the primary instructor, so the intersection of instructors in Dis and Lec sections finds the primary instructor
+
+              // When the same course is taught by multiple professors, lectures are labeled with an alphabet
+              // and corresponding discussions/labs (usually) have that letter as a prefix/suffix
+              // Intersecting all sections when multiple instructors are teaching a course results in an empty list so we intersect after grouping by letters
               const letterMatch = section.sectionNum.match(/[a-z]+/i);
               const sectionGroup = letterMatch ? letterMatch[0] : "";
               const groupedSections = course.sections
                 .filter((section) => section.sectionNum.match(sectionGroup))
                 .map((section) => new Set(section.instructors));
+              const instructorIntersection = Array.from(
+                intersectAll(groupedSections[0], ...groupedSections.slice(1)),
+              ).map((instructor) => [section.sectionCode, instructor]);
 
-              return Array.from(intersectAll(groupedSections[0], ...groupedSections.slice(1))).map(
-                (instructor) => [section.sectionCode, instructor],
-              );
+              // The above pattern is heuristic. When it doesn't work, simply return the original listed instructors
+              return instructorIntersection.length
+                ? instructorIntersection
+                : section.instructors.map((instructor) => [section.sectionCode, instructor]);
             }),
           ),
         ),

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -515,12 +515,12 @@ const doChunkUpsert = async (db: ReturnType<typeof database>, term: Term, resp: 
               // and corresponding discussions/labs have that letter as a prefix/suffix, forming a section group
               // The intersection of potentially disjoint sets of instructors from different offerings would be empty so only intersect within section group.
               const letterMatch = section.sectionNum.match(/[a-z]+/i);
-              const groupMatch = letterMatch ? letterMatch[0] : "";
-              const groupedSection = course.sections
+              const groupMatch = letterMatch?.[0] ?? "";
+              const groupedSections = course.sections
                 .filter((section) => section.sectionNum.match(groupMatch))
                 .map((section) => new Set(section.instructors));
               const instructorIntersection = Array.from(
-                intersectAll(groupedSection[0], ...groupedSection.slice(1)),
+                intersectAll(groupedSections[0], ...groupedSections.slice(1)),
               ).map((instructor) => [section.sectionCode, instructor]);
 
               // The above pattern is heuristic. When it doesn't work, simply return the original listed instructors

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -509,9 +509,9 @@ const doChunkUpsert = async (db: ReturnType<typeof database>, term: Term, resp: 
           dept.courses.flatMap((course) =>
             course.sections.flatMap((section) => {
               const letterMatch = section.sectionNum.match(/[a-z]+/i);
-              const letter = letterMatch ? letterMatch[0] : "";
+              const sectionGroup = letterMatch ? letterMatch[0] : "";
               const groupedSections = course.sections
-                .filter((section) => section.sectionNum.match(letter))
+                .filter((section) => section.sectionNum.match(sectionGroup))
                 .map((section) => new Set(section.instructors));
 
               return Array.from(intersectAll(groupedSections[0], ...groupedSections.slice(1))).map(
@@ -928,8 +928,7 @@ export async function doScrape(db: ReturnType<typeof database>) {
   const term = termsInDatabase[0];
   if (term?.name) {
     try {
-      //await scrapeTerm(db, nameToTerm(term.name));
-      await scrapeTerm(db, nameToTerm("2026 Fall"));
+      await scrapeTerm(db, nameToTerm(term.name));
     } catch (e) {
       console.error(e);
     }

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -512,15 +512,15 @@ const doChunkUpsert = async (db: ReturnType<typeof database>, term: Term, resp: 
               // Lec sections (usually) only contain the primary instructor, so the intersection of instructors in Dis and Lec sections finds the primary instructor
 
               // When a course has multiple offerings, lectures are (usually) labeled with an alphabet
-              // and corresponding discussions/labs have that letter as a prefix/suffix
-              // The intersection of potentially disjoint sets of instructors from different offerings would be empty so we only intersect within one offerings.
+              // and corresponding discussions/labs have that letter as a prefix/suffix, forming a section group
+              // The intersection of potentially disjoint sets of instructors from different offerings would be empty so only intersect within section group.
               const letterMatch = section.sectionNum.match(/[a-z]+/i);
-              const offeringGroup = letterMatch ? letterMatch[0] : "";
-              const SectionsInOffering = course.sections
-                .filter((section) => section.sectionNum.match(offeringGroup))
+              const groupMatch = letterMatch ? letterMatch[0] : "";
+              const groupedSection = course.sections
+                .filter((section) => section.sectionNum.match(groupMatch))
                 .map((section) => new Set(section.instructors));
               const instructorIntersection = Array.from(
-                intersectAll(SectionsInOffering[0], ...SectionsInOffering.slice(1)),
+                intersectAll(groupedSection[0], ...groupedSection.slice(1)),
               ).map((instructor) => [section.sectionCode, instructor]);
 
               // The above pattern is heuristic. When it doesn't work, simply return the original listed instructors

--- a/apps/data-pipeline/websoc-scraper/src/lib.ts
+++ b/apps/data-pipeline/websoc-scraper/src/lib.ts
@@ -511,16 +511,16 @@ const doChunkUpsert = async (db: ReturnType<typeof database>, term: Term, resp: 
               // Try to prevent TAs from being included
               // Lec sections (usually) only contain the primary instructor, so the intersection of instructors in Dis and Lec sections finds the primary instructor
 
-              // When the same course is taught by multiple professors, lectures are labeled with an alphabet
-              // and corresponding discussions/labs (usually) have that letter as a prefix/suffix
-              // Intersecting all sections when multiple instructors are teaching a course results in an empty list so we intersect after grouping by letters
+              // When a course has multiple offerings, lectures are (usually) labeled with an alphabet
+              // and corresponding discussions/labs have that letter as a prefix/suffix
+              // The intersection of potentially disjoint sets of instructors from different offerings would be empty so we only intersect within one offerings.
               const letterMatch = section.sectionNum.match(/[a-z]+/i);
-              const sectionGroup = letterMatch ? letterMatch[0] : "";
-              const groupedSections = course.sections
-                .filter((section) => section.sectionNum.match(sectionGroup))
+              const offeringGroup = letterMatch ? letterMatch[0] : "";
+              const SectionsInOffering = course.sections
+                .filter((section) => section.sectionNum.match(offeringGroup))
                 .map((section) => new Set(section.instructors));
               const instructorIntersection = Array.from(
-                intersectAll(groupedSections[0], ...groupedSections.slice(1)),
+                intersectAll(SectionsInOffering[0], ...SectionsInOffering.slice(1)),
               ).map((instructor) => [section.sectionCode, instructor]);
 
               // The above pattern is heuristic. When it doesn't work, simply return the original listed instructors


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously, we would find the set intersection of the list of instructors for each section in a course, and only associate those professors with the section (reasoning is described in the issue). Now, we group sections by the letters in their section num and find the intersection of instrucotor lists in that group only.  Sections without a letter in their section number is still checked against all sections.

## Related Issue

#383 

## How Has This Been Tested?

Ran the scraper locally on term "2026 Spring" and found 585 new instructors. Most of them are instructors in school of arts or upper divs where each section only contains one faculty who teaches the course (sort of like Wr 60).

## Screenshots (if appropriate):

<img width="863" height="300" alt="image" src="https://github.com/user-attachments/assets/fa7a83e8-1beb-4d41-932d-e1a6dd33117e" />
During testing, some classes have instructors that aren't listed in the relevant discussion sections, and therefore aren't saved. However, in the observed examples, the primary instructor was also a grad student, so maybe we don't want to save them anyway.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
