### PR TITLE
feat (dining): restrict past schedules by before and after dates

### DIFF
--- a/apps/api/src/graphql/schema/dining.ts
+++ b/apps/api/src/graphql/schema/dining.ts
@@ -133,7 +133,6 @@ type Schedule @cacheControl(maxAge: 3600) {
 
 input DiningEventsQuery {
   restaurantId: RestaurantId
-  includeHistorical: Boolean
   after: String
   before: String
 }
@@ -149,6 +148,7 @@ input RestaurantTodayQuery {
 
 input SchedulesQuery {
   restaurantId: RestaurantId
+  includeHistorical: Boolean
   after: String
   before: String
 }

--- a/apps/api/src/graphql/schema/dining.ts
+++ b/apps/api/src/graphql/schema/dining.ts
@@ -133,6 +133,7 @@ type Schedule @cacheControl(maxAge: 3600) {
 
 input DiningEventsQuery {
   restaurantId: RestaurantId
+  includeHistorical: Boolean
   after: String
   before: String
 }
@@ -148,7 +149,8 @@ input RestaurantTodayQuery {
 
 input SchedulesQuery {
   restaurantId: RestaurantId
-  includeHistorical: Boolean
+  after: String
+  before: String
 }
 
 extend type Query {

--- a/apps/api/src/schema/dining.ts
+++ b/apps/api/src/schema/dining.ts
@@ -11,11 +11,12 @@ export const diningEventsQuerySchema = z
     }),
     after: z.iso.date().optional().openapi({
       description:
-        "If provided, only return events whose start date is on or after this date. If neither after nor before is provided, only return events whose end date has not passed and events with no end date that were updated in the last 2 weeks",
+        "If provided, only return events whose start date is on or after this date. If neither `after` nor `before` is provided, only return events whose end date has not passed and events with no end date that were updated in the last 2 weeks",
       example: "2026-01-01",
     }),
     before: z.iso.date().optional().openapi({
-      description: "If provided, only return events whose start date is on or before this date",
+      description:
+        "If provided, only return events whose start date is on or before this date. If neither `after` nor `before` is provided, only return events whose end date has not passed and events with no end date that were updated in the last 2 weeks",
       example: "2026-12-31",
     }),
   })
@@ -266,17 +267,30 @@ export const scheduleSchema = z.object({
   updatedAt: z.date(),
 });
 
-export const schedulesQuerySchema = z.object({
-  restaurantId: restaurantIdSchema.optional().openapi({
-    description: "If present, only return schedules for the restaurant with this ID",
-  }),
-  includeHistorical: z
-    .union([z.boolean(), z.enum(["true", "false"]).transform((v) => v === "true")])
-    .optional()
-    .openapi({
-      description:
-        "If true, include past schedules whose end date is before today. Defaults to false.",
+export const schedulesQuerySchema = z
+  .object({
+    restaurantId: restaurantIdSchema.optional().openapi({
+      description: "If present, only return schedules for the restaurant with this ID",
     }),
-});
+    includeHistorical: z
+      .union([z.boolean(), z.enum(["true", "false"]).transform((v) => v === "true")])
+      .optional()
+      .openapi({
+        description:
+          "If true, include past schedules whose end date is before today. Defaults to false. `includeHistorical` is ignored if either `before` or `after` is provided",
+      }),
+    after: z.iso.date().optional().openapi({
+      description: "If provided, return only schedules active after this date.",
+      example: "2026-02-23",
+    }),
+    before: z.iso.date().optional().openapi({
+      description: "If provided, return only schedules that were active before this date.",
+      example: "2026-05-31",
+    }),
+  })
+  .refine(({ after, before }) => !after || !before || after <= before, {
+    message: "after must be on or before the before date",
+    path: ["before"],
+  });
 
 export const schedulesResponseSchema = scheduleSchema.array();

--- a/apps/api/src/services/dining.ts
+++ b/apps/api/src/services/dining.ts
@@ -7,6 +7,7 @@ import {
   inArray,
   isNull,
   lt,
+  lte,
   max,
   min,
   or,
@@ -297,12 +298,20 @@ export class DiningService {
       conds.push(eq(diningSchedule.restaurantId, query.restaurantId));
     }
 
-    if (!query.includeHistorical) {
-      // standard and current/upcoming special schedules by default
-      conds.push(
-        or(isNull(diningSchedule.endDate), gte(diningSchedule.endDate, sql`CURRENT_DATE`))!,
-      );
+    const dateRangeConds: SQL[] = [];
+
+    if (query.before) {
+      dateRangeConds.push(lte(diningSchedule.startDate, query.before));
     }
+    if (query.after) {
+      dateRangeConds.push(gte(diningSchedule.endDate, query.after));
+    }
+    if (!query.after && !query.before) {
+      if (!query.includeHistorical) {
+        dateRangeConds.push(gte(diningSchedule.endDate, sql`CURRENT_DATE`));
+      }
+    }
+    conds.push(or(isNull(diningSchedule.endDate), and(...dateRangeConds))!);
 
     type ScheduleResponse = z.infer<typeof scheduleSchema>;
 

--- a/apps/api/src/services/dining.ts
+++ b/apps/api/src/services/dining.ts
@@ -306,12 +306,13 @@ export class DiningService {
     if (query.after) {
       dateRangeConds.push(gte(diningSchedule.endDate, query.after));
     }
-    if (!query.after && !query.before) {
-      if (!query.includeHistorical) {
-        dateRangeConds.push(gte(diningSchedule.endDate, sql`CURRENT_DATE`));
-      }
+    if (!query.after && !query.before && !query.includeHistorical) {
+      dateRangeConds.push(gte(diningSchedule.endDate, sql`CURRENT_DATE`));
     }
-    conds.push(or(isNull(diningSchedule.endDate), and(...dateRangeConds))!);
+
+    if (dateRangeConds.length) {
+      conds.push(or(isNull(diningSchedule.endDate), and(...dateRangeConds))!);
+    }
 
     type ScheduleResponse = z.infer<typeof scheduleSchema>;
 

--- a/apps/api/src/services/dining.ts
+++ b/apps/api/src/services/dining.ts
@@ -293,7 +293,7 @@ export class DiningService {
   async getSchedules(
     query: z.infer<typeof schedulesQuerySchema>,
   ): Promise<z.infer<typeof scheduleSchema>[]> {
-    const conds: SQL[] = [];
+    const conds: (SQL | undefined)[] = [];
     if (query.restaurantId) {
       conds.push(eq(diningSchedule.restaurantId, query.restaurantId));
     }
@@ -311,7 +311,7 @@ export class DiningService {
     }
 
     if (dateRangeConds.length) {
-      conds.push(or(isNull(diningSchedule.endDate), and(...dateRangeConds))!);
+      conds.push(or(isNull(diningSchedule.endDate), and(...dateRangeConds)));
     }
 
     type ScheduleResponse = z.infer<typeof scheduleSchema>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In addition to old `includeHistorical` parameter that determines whether the endpoint will return all schedules or only those that have not come to pass, We now offer `before` and `after` parameters. 

`before` queries all schedules which began before a certain date
`after` queries all schedules which ended after a certain date
`before` and `after` can be used in conjunction to query windows of time

`includeHistorical` is only considered when neither `before` nor `after` is given and will return schedules that have not passed.

All queries return schedules with `null` end dates, which is the default schedule.

<!--- Describe your changes in detail -->

## Related Issue

#409 

## Motivation and Context

Previously we had if we wanted to see historical data, we had to retrieve every saved schedule. This allows users to limit the amount of data they recieve around the time they are interested in.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Runs locally on REST and GraphQL endpoints.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [x] My code requires a change to the documentation.
