### PR TITLE
feat(course-materials): sectionCode query restriction dropped

### DIFF
--- a/apps/api/src/schema/course-materials.ts
+++ b/apps/api/src/schema/course-materials.ts
@@ -36,9 +36,17 @@ export const courseMaterialsQuerySchema = z
     format: z.enum(textbookFormats, { error: "Invalid textbook format provided" }).optional(),
     requirement: z.enum(materialRequirements, { error: "Invalid requirement provided" }).optional(),
   })
-  .refine((x) => (x.department && x.courseNumber) || (x.year && x.quarter), {
-    message: "Must provide department and course number, or year and quarter",
-  });
+  .refine(
+    (x) => {
+      const baseFilterValid = (x.department && x.courseNumber) || (x.year && x.quarter);
+      const sectionCodeValid = !x.sectionCode || (x.year && x.quarter);
+      return baseFilterValid && sectionCodeValid;
+    },
+    {
+      message:
+        "If sectionCode is provided, year and quarter are required. Otherwise, provide department and courseNumber or year and quarter.",
+    },
+  );
 
 export const courseMaterialsSchema = z.object({
   year: z.string(),

--- a/apps/api/src/schema/course-materials.ts
+++ b/apps/api/src/schema/course-materials.ts
@@ -36,8 +36,8 @@ export const courseMaterialsQuerySchema = z
     format: z.enum(textbookFormats, { error: "Invalid textbook format provided" }).optional(),
     requirement: z.enum(materialRequirements, { error: "Invalid requirement provided" }).optional(),
   })
-  .refine((x) => (x.department && x.courseNumber) || (x.sectionCode && x.year && x.quarter), {
-    message: "Must provide department and course number, or section code and year/quarter",
+  .refine((x) => (x.department && x.courseNumber) || (x.year && x.quarter), {
+    message: "Must provide department and course number, or year and quarter",
   });
 
 export const courseMaterialsSchema = z.object({

--- a/apps/api/src/schema/course-materials.ts
+++ b/apps/api/src/schema/course-materials.ts
@@ -36,17 +36,12 @@ export const courseMaterialsQuerySchema = z
     format: z.enum(textbookFormats, { error: "Invalid textbook format provided" }).optional(),
     requirement: z.enum(materialRequirements, { error: "Invalid requirement provided" }).optional(),
   })
-  .refine(
-    (x) => {
-      const baseFilterValid = (x.department && x.courseNumber) || (x.year && x.quarter);
-      const sectionCodeValid = !x.sectionCode || (x.year && x.quarter);
-      return baseFilterValid && sectionCodeValid;
-    },
-    {
-      message:
-        "If sectionCode is provided, year and quarter are required. Otherwise, provide department and courseNumber or year and quarter.",
-    },
-  );
+  .refine((x) => (x.department && x.courseNumber) || (x.year && x.quarter), {
+    message: "Must provide department and courseNumber, or year and quarter",
+  })
+  .refine((x) => !x.sectionCode || (x.year && x.quarter), {
+    message: "If sectionCode is provided, year and quarter are required",
+  });
 
 export const courseMaterialsSchema = z.object({
   year: z.string(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This changes the requirements for the course-materials query from `(Year & Quarter & course code) | (Dept & course number)` to `(Year & Quarter) | (Dept & course number)`. Additionally, if sectionCode is added, year and quarter are required. This is done to allow for a dump of all course material information for a given quarter.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#417 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
