### PR TITLE
docs: update study rooms REST endpoint docs

### DIFF
--- a/apps/api/src/middleware/openapi-meta.ts
+++ b/apps/api/src/middleware/openapi-meta.ts
@@ -59,7 +59,7 @@ export const openapiMeta: OpenAPIObjectConfigure<{ Bindings: Env }, string> = {
     {
       name: "Study Rooms",
       description:
-        "Data sourced from the UCI Libraries reservation site (https://spaces.lib.uci.edu/) and Plaza Verde amenity reservations site (https://outlook.office365.com/book/PlazaVerde3@americancampus.onmicrosoft.com/)",
+        "Data sourced from the UCI Libraries reservation site (https://spaces.lib.uci.edu/), UCI OIT Space Scheduler site (https://scheduler.oit.uci.edu/reserve/Antcaves), and Plaza Verde amenity reservations site (https://outlook.office365.com/book/PlazaVerde3@americancampus.onmicrosoft.com/)",
     },
     { name: "AP Exams", description: "Data concerning AP Exams as they relate to UCI." },
     {

--- a/apps/api/src/middleware/openapi-meta.ts
+++ b/apps/api/src/middleware/openapi-meta.ts
@@ -59,7 +59,7 @@ export const openapiMeta: OpenAPIObjectConfigure<{ Bindings: Env }, string> = {
     {
       name: "Study Rooms",
       description:
-        "Data sourced from the UCI Libraries reservation site (https://spaces.lib.uci.edu/), UCI OIT Space Scheduler site (https://scheduler.oit.uci.edu/reserve/Antcaves), and Plaza Verde amenity reservations site (https://outlook.office365.com/book/PlazaVerde3@americancampus.onmicrosoft.com/)",
+        "Data sourced from the UCI Libraries reservation site (https://spaces.lib.uci.edu/), UCI OIT Space Scheduler site (https://scheduler.oit.uci.edu/reserve/), and Plaza Verde amenity reservations site (https://outlook.office365.com/book/PlazaVerde3@americancampus.onmicrosoft.com/)",
     },
     { name: "AP Exams", description: "Data concerning AP Exams as they relate to UCI." },
     {

--- a/apps/api/src/middleware/openapi-meta.ts
+++ b/apps/api/src/middleware/openapi-meta.ts
@@ -59,7 +59,7 @@ export const openapiMeta: OpenAPIObjectConfigure<{ Bindings: Env }, string> = {
     {
       name: "Study Rooms",
       description:
-        "Data sourced from the UCI Libraries reservation site (https://spaces.lib.uci.edu/), UCI OIT Space Scheduler site (https://scheduler.oit.uci.edu/reserve/), and Plaza Verde amenity reservations site (https://outlook.office365.com/book/PlazaVerde3@americancampus.onmicrosoft.com/)",
+        "Data sourced from the [UCI Libraries reservation site](https://spaces.lib.uci.edu/), [UCI OIT Space Scheduler site](https://scheduler.oit.uci.edu/reserve/), and [Plaza Verde amenity reservations site](https://outlook.office365.com/book/PlazaVerde3@americancampus.onmicrosoft.com/).",
     },
     { name: "AP Exams", description: "Data concerning AP Exams as they relate to UCI." },
     {


### PR DESCRIPTION
## Description

changed study rooms REST endpoint openapi meta docs to include the link to the UCI OIT space scheduler for ALP

## Related Issue

#387 

## Motivation and Context

the docs currently only link the libraries spaces site and the plaza verde booking site, but doesn't include the alp booking site link

## How Has This Been Tested?

ran local dev environment and checked localhost references page

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code involves a change to the database schema.
- [x] My code requires a change to the documentation.
