### PR TITLE
fix(degreeworks-scraper): deduplicate by major {code->name}

### DIFF
--- a/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
+++ b/apps/data-pipeline/degreeworks-scraper/src/components/Scraper.ts
@@ -21,8 +21,8 @@ import {
 
 const JWT_HEADER_PREFIX_LENGTH = 7;
 
-// 'majorName;specCode'. If no specialization is taken, simply 'majorName'
-type MajorSpecId = string | `${string};${string}`;
+// 'degreeCode-majorCode;specCode'. If no specialization is taken, simply 'degreeCode-majorCode'
+type MajorSpecId = string | `${string}-${string}` | `${string}-${string};${string}`;
 
 export class Scraper {
   private ap!: AuditParser;
@@ -56,8 +56,16 @@ export class Scraper {
     );
   }
 
-  private asMajorSpecId(majorName: string, specCode: string | undefined): MajorSpecId {
-    return specCode ? `${majorName};${specCode}` : majorName;
+  private asMajorSpecId(
+    degreeCode: string | undefined,
+    majorCode: string,
+    specCode: string | undefined,
+  ): MajorSpecId {
+    if (degreeCode === undefined)
+      throw Error(
+        `No degree code given. asMajorSpecId was probably called with a non-major program id`,
+      );
+    return `${degreeCode ? `${degreeCode}-` : ""}${majorCode}${specCode ? `;${specCode}` : ""}`;
   }
 
   private findDwNameFor(
@@ -168,12 +176,12 @@ export class Scraper {
         console.log(`Requirements block not found ${majorLogInfo}`);
         continue;
       }
-      if (ret.has(this.asMajorSpecId(majorAudit.title, specCode))) {
+      if (ret.has(this.asMajorSpecId(degreeCode, majorCode, specCode))) {
         console.log(`Requirements block already exists for "${majorAudit.title}" ${majorLogInfo}`);
         continue;
       }
 
-      ret.set(this.asMajorSpecId(majorAudit.title, specCode), {
+      ret.set(this.asMajorSpecId(degreeCode, majorCode, specCode), {
         college: audit?.college
           ? await this.ap.parseBlock(
               `${collegeCode}-COLLEGE-${majorCode}-${degreeCode}`,
@@ -203,7 +211,7 @@ export class Scraper {
     // as of this commit, this spec is seemingly valid with any major but that's not really true
     if (specCode === "OACSC") {
       // "optional american chemical society certification"
-      const inMap = this.parsedPrograms.get(this.asMajorSpecId("Major in Chemistry", undefined));
+      const inMap = this.parsedPrograms.get(this.asMajorSpecId("BS", "153", undefined));
       return inMap ? [inMap.major] : [];
     }
 
@@ -330,7 +338,7 @@ export class Scraper {
         if (got !== null) {
           specBlock = got.block;
           const majorProgram = this.parsedPrograms.get(
-            this.asMajorSpecId(got.parent.name, undefined),
+            this.asMajorSpecId(got.parent.degreeType, got.parent.code, undefined),
           );
           if (majorProgram) {
             foundMajor = majorProgram.major;
@@ -446,7 +454,7 @@ export class Scraper {
     // cleaner way to address this, but this is such an insanely niche case
     // that it's probably not worth the effort to write a general solution.
 
-    const x = this.parsedPrograms.get(this.asMajorSpecId("Major in Art History", undefined));
+    const x = this.parsedPrograms.get(this.asMajorSpecId("BA", "093", undefined));
     const y = this.parsedSpecializations.get("AHGEO")?.[2];
     const z = this.parsedSpecializations.get("AHPER")?.[2];
     if (x && y && z) {
@@ -455,9 +463,9 @@ export class Scraper {
       x.major.requirements = [...x.major.requirements, ...y.requirements, ...z.requirements];
       this.parsedSpecializations.delete("AHGEO");
       this.parsedSpecializations.delete("AHPER");
-      this.parsedPrograms.delete(this.asMajorSpecId("Major in Art History", "AHPER"));
-      this.parsedPrograms.delete(this.asMajorSpecId("Major in Art History", "AHGEO"));
-      this.parsedPrograms.set(this.asMajorSpecId("Major in Art History", undefined), x);
+      this.parsedPrograms.delete(this.asMajorSpecId("BA", "093", "AHPER"));
+      this.parsedPrograms.delete(this.asMajorSpecId("BA", "093", "AHGEO"));
+      this.parsedPrograms.set(this.asMajorSpecId("BA", "094", undefined), x);
     }
 
     this.done = true;


### PR DESCRIPTION
When we get the list of potential programs (schoolCode, degreeCode, collegeCode, majorCode, specCode), DW often returns duplicates.
when scraping for major programs, we save each scraped audit as <Major_Name>;<Spec_Code> (i.e "Major in Computer Science;201B", "Major in Computer Science", etc)
This works for current catalogs. However, from #344 which saves historical catalog years, we discover that historically, there is no name differentiation between majors of the same subject with by different degrees.
For example, in the year 20132014, both MS in Math and BS in Math were labeled as "Major In Mathematics". This caused the scraper to only scrape the first program, and mistakenly skip the others as they had the same `majorSpecId` (current catalog saves MS-540 as "MS in Mathematics" which is why wasn't noticed before).

We changed `majorSpecId` to save <Degree_Code>-<Major_Code>[;<Spec_Code>]. (ie BS-201;201B)

Scrape of catalog year 20132014 found 16 new programs (86 -> 102)
Scrape of catalog year 20252026 remained the same(266)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
