### PR TITLE
fix: split prerequisite list on ' AND ' instead of 'AND' (#439)

### DIFF
--- a/apps/data-pipeline/course-scraper/src/index.ts
+++ b/apps/data-pipeline/course-scraper/src/index.ts
@@ -236,7 +236,7 @@ function buildORLeaf(prereqTree: PrerequisiteTree, prereq: string) {
 
 function buildPrereqTree(prereqList: string): PrerequisiteTree {
   const prereqTree: PrerequisiteTree = { AND: [], NOT: [] };
-  const prereqs = prereqList.split(/AND/).map((prereq) => prereq.trim());
+  const prereqs = prereqList.split(/ AND /).map((prereq) => prereq.trim());
   for (const prereq of prereqs) {
     if (prereq[0] === "(") {
       const orReqs = prereq


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changed the prerequisite list splitting regex from `/AND/` to `/ AND /` so that it only splits on the standalone word "AND" surrounded by spaces, rather than splitting on "AND" appearing anywhere in a string (e.g. inside course names like "DANCE").

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->https://github.com/icssc/anteater-api/issues/439

## Motivation and Context

The previous regex was too aggressive and would incorrectly split on "AND" appearing as part of a word, causing prerequisite parsing to produce incorrect results.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code involves a change to the database schema.
- [ ] My code requires a change to the documentation.
