### PR TITLE
revert(course): reverted #439

### DIFF
--- a/apps/data-pipeline/course-scraper/src/index.ts
+++ b/apps/data-pipeline/course-scraper/src/index.ts
@@ -236,7 +236,7 @@ function buildORLeaf(prereqTree: PrerequisiteTree, prereq: string) {
 
 function buildPrereqTree(prereqList: string): PrerequisiteTree {
   const prereqTree: PrerequisiteTree = { AND: [], NOT: [] };
-  const prereqs = prereqList.split(/ AND /).map((prereq) => prereq.trim());
+  const prereqs = prereqList.split(/AND/).map((prereq) => prereq.trim());
   for (const prereq of prereqs) {
     if (prereq[0] === "(") {
       const orReqs = prereq


### PR DESCRIPTION
Reverts icssc/anteater-api#447

We ran into a problem where ANDs are often unspaced, invalidating many ANDs that are correct. Another look at this issue is required